### PR TITLE
タスク作成APIの実装

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.119",
+    "@types/uuid": "^9.0.2",
     "aws-sdk-client-mock": "^3.0.0"
   },
   "dependencies": {

--- a/functions/src/handlers/create-task-handler.ts
+++ b/functions/src/handlers/create-task-handler.ts
@@ -1,0 +1,39 @@
+import { APIGatewayEvent } from 'aws-lambda';
+import { z } from 'zod';
+import {
+  RequestHandlerWithoutContext,
+  handlerFactory,
+} from './factory/handler-factory';
+import { createTaskUseCase } from '../usecases/create-task-usecase';
+import { CreateTaskRequestSchema } from './http/requestSchemas/create-task-request';
+import { LambdaResponse, httpResponse } from './http/http-response';
+import { HttpStatus } from './http/http-status';
+import { ErrorCode } from '../common/errors/error-codes';
+import { AppError } from '../common/errors/app-errors';
+
+const EventSchema = z.object({
+  body: z.string(),
+});
+
+const requestHandler: RequestHandlerWithoutContext = async (
+  event: APIGatewayEvent,
+): Promise<LambdaResponse> => {
+  const eventResult = EventSchema.safeParse(event);
+
+  if (!eventResult.success) {
+    throw new AppError(ErrorCode.INVALID_REQUEST);
+  }
+
+  const body = eventResult.data.body;
+  const bodyResult = CreateTaskRequestSchema.safeParse(JSON.parse(body));
+
+  if (!bodyResult.success) {
+    throw new AppError(ErrorCode.INVALID_REQUEST);
+  }
+
+  const createdTask = await createTaskUseCase(bodyResult.data);
+
+  return httpResponse(HttpStatus.CREATED).withBody(createdTask);
+};
+
+export const handler = handlerFactory('createTask', requestHandler);

--- a/functions/src/handlers/create-task-handler.ts
+++ b/functions/src/handlers/create-task-handler.ts
@@ -1,5 +1,4 @@
 import { APIGatewayEvent } from 'aws-lambda';
-import { z } from 'zod';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,
@@ -8,30 +7,15 @@ import { createTaskUseCase } from '../usecases/create-task-usecase';
 import { CreateTaskRequestSchema } from './http/requestSchemas/create-task-request';
 import { LambdaResponse, httpResponse } from './http/http-response';
 import { HttpStatus } from './http/http-status';
-import { ErrorCode } from '../common/errors/error-codes';
-import { AppError } from '../common/errors/app-errors';
-
-const EventSchema = z.object({
-  body: z.string(),
-});
+import { validateBody, validateEvent } from './http/validators';
 
 const requestHandler: RequestHandlerWithoutContext = async (
   event: APIGatewayEvent,
 ): Promise<LambdaResponse> => {
-  const eventResult = EventSchema.safeParse(event);
+  const validEvent = validateEvent(event);
+  const validBody = validateBody(CreateTaskRequestSchema, validEvent.body);
 
-  if (!eventResult.success) {
-    throw new AppError(ErrorCode.INVALID_REQUEST);
-  }
-
-  const body = eventResult.data.body;
-  const bodyResult = CreateTaskRequestSchema.safeParse(JSON.parse(body));
-
-  if (!bodyResult.success) {
-    throw new AppError(ErrorCode.INVALID_REQUEST);
-  }
-
-  const createdTask = await createTaskUseCase(bodyResult.data);
+  const createdTask = await createTaskUseCase(validBody);
 
   return httpResponse(HttpStatus.CREATED).withBody(createdTask);
 };

--- a/functions/src/handlers/http/requestSchemas/create-task-request.ts
+++ b/functions/src/handlers/http/requestSchemas/create-task-request.ts
@@ -1,0 +1,7 @@
+import * as z from 'zod';
+
+export const CreateTaskRequestSchema = z.object({
+  title: z.string().min(1).max(100),
+  description: z.string().max(1000).optional(),
+});
+export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>;

--- a/functions/src/handlers/http/validators.ts
+++ b/functions/src/handlers/http/validators.ts
@@ -1,0 +1,42 @@
+import { ZodObject, ZodRawShape, z } from 'zod';
+import { AppError } from '../../common/errors/app-errors';
+import { ErrorCode } from '../../common/errors/error-codes';
+import { APIGatewayEvent } from 'aws-lambda';
+
+const EventSchema = z.object({
+  body: z.string(),
+});
+
+const EventWithPathParamSchema = z.object({
+  pathParameters: z.object({ id: z.string().uuid() }),
+});
+
+export const validateEvent = (event: APIGatewayEvent) => {
+  const eventResult = EventSchema.safeParse(event);
+
+  if (!eventResult.success) {
+    throw new AppError(ErrorCode.INVALID_REQUEST);
+  }
+  return eventResult.data;
+};
+
+export const validateEventWithPathParams = (event: APIGatewayEvent) => {
+  const eventResult = EventWithPathParamSchema.safeParse(event);
+
+  if (!eventResult.success) {
+    throw new AppError(ErrorCode.INVALID_REQUEST);
+  }
+  return eventResult.data;
+};
+
+export const validateBody = <T extends ZodRawShape>(
+  schema: ZodObject<T>,
+  str: string,
+) => {
+  const bodyResult = schema.safeParse(JSON.parse(str));
+
+  if (!bodyResult.success) {
+    throw new AppError(ErrorCode.INVALID_REQUEST);
+  }
+  return bodyResult.data;
+};

--- a/functions/src/infrastructure/ddb/tasks-table.ts
+++ b/functions/src/infrastructure/ddb/tasks-table.ts
@@ -1,10 +1,17 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  PutCommandInput,
+} from '@aws-sdk/lib-dynamodb';
 
 import { logger } from '../../common/logger';
 import { ddbFactory } from './factory/ddb-factory';
 import { DdbInternalServerError } from './errors/ddb-errors';
 import { TaskItem, TaskItemSchema } from '../../domain/taskItem';
+import { CreateTaskRequest } from '../../handlers/http/requestSchemas/create-task-request';
+import { v4 as uuidv4 } from 'uuid';
 
 const TABLE_NAME = process.env.TASKS_TABLE_NAME;
 const AWS_REGION = process.env.AWS_REGION;
@@ -16,6 +23,28 @@ const dynamoDBClient = new DynamoDBClient({
 });
 
 const dynamoDb = DynamoDBDocumentClient.from(dynamoDBClient);
+
+const createTaskItemImpl = async (body: CreateTaskRequest): Promise<string> => {
+  const uuid = uuidv4();
+  const now = new Date().toISOString();
+
+  const putCommandInput: PutCommandInput = {
+    TableName: TABLE_NAME,
+    Item: {
+      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246', // fixme 認証を導入するまでは固定値を使う
+      taskId: uuid,
+      title: body.title,
+      description: body.description ? body.description : '',
+      completed: false,
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+  const putCommand = new PutCommand(putCommandInput);
+  await dynamoDb.send(putCommand);
+
+  return uuid;
+};
 
 const getTaskItemByIdImpl = async (
   taskId: string,
@@ -50,3 +79,4 @@ export const getTaskItemById = ddbFactory(
   'getTaskItemById',
   getTaskItemByIdImpl,
 );
+export const createTaskItem = ddbFactory('createTaskItem', createTaskItemImpl);

--- a/functions/src/usecases/create-task-usecase.ts
+++ b/functions/src/usecases/create-task-usecase.ts
@@ -1,0 +1,19 @@
+import { Task, toTask } from '../domain/task';
+import { TaskNotFoundError } from '../domain/errors/task-errors';
+import { useCaseFactory } from './factory/usecase-factory';
+import { CreateTaskRequest } from '../handlers/http/requestSchemas/create-task-request';
+import {
+  createTaskItem,
+  getTaskItemById,
+} from '../infrastructure/ddb/tasks-table';
+
+const createTask = async (body: CreateTaskRequest): Promise<Task> => {
+  const newTaskId = await createTaskItem(body);
+  const newTaskRecord = await getTaskItemById(newTaskId);
+  if (!newTaskRecord) {
+    throw new TaskNotFoundError('Task not found after creation.');
+  }
+  return toTask(newTaskRecord);
+};
+
+export const createTaskUseCase = useCaseFactory('createTask', createTask);

--- a/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
@@ -1,12 +1,46 @@
 import { TaskItem } from '../../../../src/domain/taskItem';
+import { CreateTaskRequest } from '../../../../src/handlers/http/requestSchemas/create-task-request';
 
-import { getTaskItemById } from '../../../../src/infrastructure/ddb/tasks-table';
+import {
+  createTaskItem,
+  getTaskItemById,
+} from '../../../../src/infrastructure/ddb/tasks-table';
 import {
   createTable,
   deleteTable,
   deleteTask,
   putTask,
 } from '../../../helpers/tasks-table-helpers';
+describe('createTask', () => {
+  const dummyTaskBody: CreateTaskRequest = {
+    title: 'スーパーに買い物に行く',
+    description: '牛乳と卵を買う',
+  };
+
+  beforeAll(async () => {
+    await createTable();
+  });
+
+  afterAll(async () => {
+    await deleteTable();
+  });
+
+  test('should add a new task to the DynamoDB table', async () => {
+    const newTaskId = await createTaskItem(dummyTaskBody);
+
+    const createdTask = await getTaskItemById(newTaskId);
+    if (!createdTask) {
+      throw new Error('Created task not found');
+    }
+    expect(createdTask).toBeDefined();
+
+    expect(createdTask.taskId).toEqual(newTaskId);
+
+    expect(createdTask.title).toEqual(dummyTaskBody.title);
+    expect(createdTask.description).toEqual(dummyTaskBody.description);
+    expect(createdTask.completed).toEqual(false);
+  });
+});
 
 describe('getTaskItemById', () => {
   const dummyTaskItem: TaskItem = {

--- a/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
@@ -11,21 +11,19 @@ import {
   deleteTask,
   putTask,
 } from '../../../helpers/tasks-table-helpers';
-describe('createTask', () => {
-  const dummyTaskBody: CreateTaskRequest = {
-    title: 'スーパーに買い物に行く',
-    description: '牛乳と卵を買う',
-  };
-
+describe('createTaskItem', () => {
   beforeAll(async () => {
     await createTable();
   });
-
   afterAll(async () => {
     await deleteTable();
   });
 
   test('should add a new task to the DynamoDB table', async () => {
+    const dummyTaskBody: CreateTaskRequest = {
+      title: 'スーパーに買い物に行く',
+      description: '牛乳と卵を買う',
+    };
     const newTaskId = await createTaskItem(dummyTaskBody);
 
     const createdTask = await getTaskItemById(newTaskId);
@@ -43,15 +41,6 @@ describe('createTask', () => {
 });
 
 describe('getTaskItemById', () => {
-  const dummyTaskItem: TaskItem = {
-    userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
-    taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
-    title: 'スーパーに買い物に行く',
-    completed: false,
-    description: '牛乳と卵を買う',
-    createdAt: '2021-06-22T14:24:02.071Z',
-    updatedAt: '2021-06-22T14:24:02.071Z',
-  };
   beforeAll(async () => {
     await createTable();
   });
@@ -64,6 +53,15 @@ describe('getTaskItemById', () => {
   afterEach(async () => {
     await deleteTask(dummyTaskItem.taskId);
   });
+  const dummyTaskItem: TaskItem = {
+    userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+    taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    description: '牛乳と卵を買う',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
 
   test('should return the dummy task item by task ID', async () => {
     const TaskItem = await getTaskItemById(dummyTaskItem.taskId);

--- a/functions/tests/medium/usecases/create-task-usecase.test.ts
+++ b/functions/tests/medium/usecases/create-task-usecase.test.ts
@@ -4,11 +4,6 @@ import { getTaskItemById } from '../../../src/infrastructure/ddb/tasks-table';
 import { createTaskUseCase } from '../../../src/usecases/create-task-usecase';
 import { createTable, deleteTable } from '../../helpers/tasks-table-helpers';
 
-const taskBody: CreateTaskRequest = {
-  title: 'コーヒーを淹れる',
-  description: '濃いめで',
-};
-
 describe('createTaskUseCase', () => {
   beforeAll(async () => {
     await createTable();
@@ -18,7 +13,11 @@ describe('createTaskUseCase', () => {
   });
 
   test('should create a task successfully in the mock database', async () => {
-    const createdTask = await createTaskUseCase(taskBody);
+    const createTaskReq: CreateTaskRequest = {
+      title: 'コーヒーを淹れる',
+      description: '濃いめで',
+    };
+    const createdTask = await createTaskUseCase(createTaskReq);
 
     const fetchedTaskItem = await getTaskItemById(createdTask.id);
     const fetchedTask = toTask(fetchedTaskItem!);

--- a/functions/tests/medium/usecases/create-task-usecase.ts
+++ b/functions/tests/medium/usecases/create-task-usecase.ts
@@ -1,0 +1,28 @@
+import { toTask } from '../../../src/domain/task';
+import { CreateTaskRequest } from '../../../src/handlers/http/requestSchemas/create-task-request';
+import { getTaskItemById } from '../../../src/infrastructure/ddb/tasks-table';
+import { createTaskUseCase } from '../../../src/usecases/create-task-usecase';
+import { createTable, deleteTable } from '../../helpers/tasks-table-helpers';
+
+const taskBody: CreateTaskRequest = {
+  title: 'コーヒーを淹れる',
+  description: '濃いめで',
+};
+
+describe('createTaskUseCase', () => {
+  beforeAll(async () => {
+    await createTable();
+  });
+  afterAll(async () => {
+    await deleteTable();
+  });
+
+  test('should create a task successfully in the mock database', async () => {
+    const createdTask = await createTaskUseCase(taskBody);
+
+    const fetchedTaskItem = await getTaskItemById(createdTask.id);
+    const fetchedTask = toTask(fetchedTaskItem!);
+
+    expect(fetchedTask).toEqual(createdTask);
+  });
+});

--- a/functions/tests/small/handlers/create-task-handler.test.ts
+++ b/functions/tests/small/handlers/create-task-handler.test.ts
@@ -1,0 +1,90 @@
+import { handler } from '../../../src/handlers/create-task-handler';
+import { Task } from '../../../src/domain/task';
+import { APIGatewayEvent, Context } from 'aws-lambda';
+import { createTaskUseCase } from '../../../src/usecases/create-task-usecase';
+import { CreateTaskRequest } from '../../../src/handlers/http/requestSchemas/create-task-request';
+import { ErrorCode } from '../../../src/common/errors/error-codes';
+
+jest.mock('../../../src/usecases/create-task-usecase');
+
+describe('Create Task Request Handler', () => {
+  const dummyTask: Task = {
+    id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    description: '牛乳と卵を買う',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+
+  const dummyTaskWithoutDescription: Task = {
+    id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+
+  const dummyBody: CreateTaskRequest = {
+    title: 'スーパーに買い物に行く',
+    description: '牛乳と卵を買う',
+  };
+
+  const dummyBodyWithoutDescription: CreateTaskRequest = {
+    title: 'スーパーに買い物に行く',
+  };
+
+  const dummyBodyWithoutTitle = {
+    description: '牛乳と卵を買う',
+  };
+
+  const mockValidEvent = {
+    body: JSON.stringify(dummyBody),
+  } as unknown as APIGatewayEvent;
+
+  const mockValidEventWithoutDescription = {
+    body: JSON.stringify(dummyBodyWithoutDescription),
+  } as unknown as APIGatewayEvent;
+
+  const mockInvalidEventWithoutTitle = {
+    body: JSON.stringify(dummyBodyWithoutTitle),
+  } as unknown as APIGatewayEvent;
+
+  const mockInvalidEventNullBody = {
+    body: JSON.stringify(null),
+  } as unknown as APIGatewayEvent;
+
+  const mockContext = {} as Context;
+
+  beforeEach(() => {
+    (createTaskUseCase as jest.Mock).mockClear();
+  });
+
+  test.each`
+    request                             | body                           | task
+    ${mockValidEvent}                   | ${dummyBody}                   | ${dummyTask}
+    ${mockValidEventWithoutDescription} | ${dummyBodyWithoutDescription} | ${dummyTaskWithoutDescription}
+  `(
+    'should return 201 status for a valid request',
+    async ({ request, body, task }) => {
+      (createTaskUseCase as jest.Mock).mockResolvedValueOnce(task);
+
+      const result = await handler(request, mockContext);
+      expect(result.statusCode).toBe(201);
+      expect(JSON.parse(result.body!)).toEqual(task);
+      expect(createTaskUseCase).toHaveBeenCalledTimes(1);
+      expect(createTaskUseCase).toHaveBeenCalledWith(body);
+    },
+  );
+
+  test.each`
+    request
+    ${mockInvalidEventNullBody}
+    ${mockInvalidEventWithoutTitle}
+  `('should return 400 status for an invalid request', async ({ request }) => {
+    const result = await handler(request, mockContext);
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body!).code).toBe(ErrorCode.INVALID_REQUEST);
+    expect(createTaskUseCase).toHaveBeenCalledTimes(0);
+  });
+});

--- a/functions/tests/small/handlers/create-task-handler.test.ts
+++ b/functions/tests/small/handlers/create-task-handler.test.ts
@@ -8,6 +8,10 @@ import { ErrorCode } from '../../../src/common/errors/error-codes';
 jest.mock('../../../src/usecases/create-task-usecase');
 
 describe('Create Task Request Handler', () => {
+  beforeEach(() => {
+    (createTaskUseCase as jest.Mock).mockClear();
+  });
+
   const dummyTask: Task = {
     id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
     title: 'スーパーに買い物に行く',
@@ -25,51 +29,47 @@ describe('Create Task Request Handler', () => {
     updatedAt: '2021-06-22T14:24:02.071Z',
   };
 
-  const dummyBody: CreateTaskRequest = {
+  const createReq: CreateTaskRequest = {
     title: 'スーパーに買い物に行く',
     description: '牛乳と卵を買う',
   };
 
-  const dummyBodyWithoutDescription: CreateTaskRequest = {
+  const createReqWithoutDescription: CreateTaskRequest = {
     title: 'スーパーに買い物に行く',
   };
 
-  const dummyBodyWithoutTitle = {
+  const createReqWithoutTitle = {
     description: '牛乳と卵を買う',
   };
 
-  const mockValidEvent = {
-    body: JSON.stringify(dummyBody),
+  const validEvent = {
+    body: JSON.stringify(createReq),
   } as unknown as APIGatewayEvent;
 
-  const mockValidEventWithoutDescription = {
-    body: JSON.stringify(dummyBodyWithoutDescription),
+  const validEventWithoutDescription = {
+    body: JSON.stringify(createReqWithoutDescription),
   } as unknown as APIGatewayEvent;
 
-  const mockInvalidEventWithoutTitle = {
-    body: JSON.stringify(dummyBodyWithoutTitle),
+  const InvalidEventWithoutTitle = {
+    body: JSON.stringify(createReqWithoutTitle),
   } as unknown as APIGatewayEvent;
 
-  const mockInvalidEventNullBody = {
+  const InvalidEventNullBody = {
     body: JSON.stringify(null),
   } as unknown as APIGatewayEvent;
 
-  const mockContext = {} as Context;
-
-  beforeEach(() => {
-    (createTaskUseCase as jest.Mock).mockClear();
-  });
+  const dummyContext = {} as Context;
 
   test.each`
-    request                             | body                           | task
-    ${mockValidEvent}                   | ${dummyBody}                   | ${dummyTask}
-    ${mockValidEventWithoutDescription} | ${dummyBodyWithoutDescription} | ${dummyTaskWithoutDescription}
+    request                         | body                           | task
+    ${validEvent}                   | ${createReq}                   | ${dummyTask}
+    ${validEventWithoutDescription} | ${createReqWithoutDescription} | ${dummyTaskWithoutDescription}
   `(
     'should return 201 status for a valid request',
     async ({ request, body, task }) => {
       (createTaskUseCase as jest.Mock).mockResolvedValueOnce(task);
 
-      const result = await handler(request, mockContext);
+      const result = await handler(request, dummyContext);
       expect(result.statusCode).toBe(201);
       expect(JSON.parse(result.body!)).toEqual(task);
       expect(createTaskUseCase).toHaveBeenCalledTimes(1);
@@ -79,10 +79,10 @@ describe('Create Task Request Handler', () => {
 
   test.each`
     request
-    ${mockInvalidEventNullBody}
-    ${mockInvalidEventWithoutTitle}
+    ${InvalidEventNullBody}
+    ${InvalidEventWithoutTitle}
   `('should return 400 status for an invalid request', async ({ request }) => {
-    const result = await handler(request, mockContext);
+    const result = await handler(request, dummyContext);
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body!).code).toBe(ErrorCode.INVALID_REQUEST);
     expect(createTaskUseCase).toHaveBeenCalledTimes(0);

--- a/functions/tests/small/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/small/infrastructure/ddb/tasks-table.test.ts
@@ -14,9 +14,9 @@ import { TaskItem } from '../../../../src/domain/taskItem';
 import { z } from 'zod';
 
 const documentMockClient = mockClient(DynamoDBDocumentClient);
-
 const TASK_TABLE_NAME = process.env.TASKS_TABLE_NAME;
-describe('createTaskImpl', () => {
+
+describe('createTaskItem', () => {
   afterEach(() => {
     documentMockClient.reset();
   });
@@ -72,11 +72,11 @@ describe('createTaskImpl', () => {
 });
 
 describe('getTaskItemById', () => {
-  const mockTaskId = '1a7244c5-06d3-47e2-560e-f0b5534c8246';
-
   beforeEach(() => {
     documentMockClient.reset();
   });
+
+  const dummyTaskId = '1a7244c5-06d3-47e2-560e-f0b5534c8246';
 
   test('should return a task record for a valid task ID', async () => {
     const dummyTaskItem: TaskItem = {
@@ -91,7 +91,7 @@ describe('getTaskItemById', () => {
 
     documentMockClient.on(GetCommand).resolves({ Item: dummyTaskItem });
 
-    const result = await getTaskItemById(mockTaskId);
+    const result = await getTaskItemById(dummyTaskId);
 
     const callsOfGet = documentMockClient.commandCalls(GetCommand);
     expect(callsOfGet).toHaveLength(1);
@@ -99,7 +99,7 @@ describe('getTaskItemById', () => {
       TableName: TASK_TABLE_NAME,
       Key: {
         userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
-        taskId: mockTaskId,
+        taskId: dummyTaskId,
       },
     });
     expect(result).toEqual(dummyTaskItem);
@@ -119,7 +119,7 @@ describe('getTaskItemById', () => {
     };
 
     documentMockClient.on(GetCommand).resolves({ Item: invalidTaskRecord });
-    await expect(getTaskItemById(mockTaskId)).rejects.toThrow(
+    await expect(getTaskItemById(dummyTaskId)).rejects.toThrow(
       DdbInternalServerError,
     );
     expect(documentMockClient.calls()).toHaveLength(1);

--- a/functions/tests/small/usecases/create-task-usecase.test.ts
+++ b/functions/tests/small/usecases/create-task-usecase.test.ts
@@ -1,0 +1,98 @@
+import { Task, toTask } from '../../../src/domain/task';
+import { TaskItem } from '../../../src/domain/taskItem';
+import { createTaskUseCase } from '../../../src/usecases/create-task-usecase';
+import { CreateTaskRequest } from '../../../src/handlers/http/requestSchemas/create-task-request';
+import { AppError } from '../../../src/common/errors/app-errors';
+import { ErrorCode } from '../../../src/common/errors/error-codes';
+import {
+  createTaskItem,
+  getTaskItemById,
+} from '../../../src/infrastructure/ddb/tasks-table';
+
+jest.mock('../../../src/infrastructure/ddb/tasks-table');
+jest.mock('../../../src/domain/task');
+
+const dummyCreateTaskRequest: CreateTaskRequest = {
+  title: 'コーヒーを淹れる',
+  description: '濃いめで',
+};
+const dummyCreateTaskRequestWithoutDescription: CreateTaskRequest = {
+  title: 'コーヒーを淹れる',
+};
+
+const dummyTask: Task = {
+  id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+  title: 'スーパーに買い物に行く',
+  completed: false,
+  description: '牛乳と卵を買う',
+  createdAt: '2021-06-22T14:24:02.071Z',
+  updatedAt: '2021-06-22T14:24:02.071Z',
+};
+const dummyTaskWithoutDescription: Task = {
+  id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+  title: 'スーパーに買い物に行く',
+  completed: false,
+  description: '',
+  createdAt: '2021-06-22T14:24:02.071Z',
+  updatedAt: '2021-06-22T14:24:02.071Z',
+};
+
+const validTaskId = 'valid-task-id';
+
+const dummyTaskRecord: TaskItem = {
+  userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+  taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+  title: 'スーパーに買い物に行く',
+  completed: false,
+  description: '牛乳と卵を買う',
+  createdAt: '2021-06-22T14:24:02.071Z',
+  updatedAt: '2021-06-22T14:24:02.071Z',
+};
+
+describe('createTaskUseCase', () => {
+  beforeEach(() => {
+    (createTaskItem as jest.Mock).mockClear();
+    (getTaskItemById as jest.Mock).mockClear();
+    (toTask as jest.Mock).mockClear();
+  });
+
+  test.each`
+    request                                     | task
+    ${dummyCreateTaskRequest}                   | ${dummyTask}
+    ${dummyCreateTaskRequestWithoutDescription} | ${dummyTaskWithoutDescription}
+  `('should create a task successfully', async ({ request, task }) => {
+    (createTaskItem as jest.Mock).mockResolvedValue(validTaskId);
+    (getTaskItemById as jest.Mock).mockResolvedValue(dummyTaskRecord);
+    (toTask as jest.Mock).mockReturnValue(task);
+
+    const result = await createTaskUseCase(request);
+
+    expect(createTaskItem).toHaveBeenCalledTimes(1);
+    expect(createTaskItem).toHaveBeenCalledWith(request);
+
+    expect(getTaskItemById).toHaveBeenCalledTimes(1);
+    expect(getTaskItemById).toHaveBeenCalledWith(validTaskId);
+
+    expect(toTask).toHaveBeenCalledTimes(1);
+    expect(toTask).toHaveBeenCalledWith(dummyTaskRecord);
+
+    expect(result).toEqual(task);
+  });
+
+  test('should throw AppError with TASK_NOT_FOUND if task record is not found', async () => {
+    const invalidTaskId = 'invalid-task-id';
+
+    (createTaskItem as jest.Mock).mockResolvedValue(invalidTaskId);
+    (getTaskItemById as jest.Mock).mockResolvedValue(null);
+
+    await expect(createTaskUseCase(dummyCreateTaskRequest)).rejects.toThrow(
+      new AppError(ErrorCode.TASK_NOT_FOUND),
+    );
+
+    expect(createTaskItem).toHaveBeenCalledTimes(1);
+    expect(createTaskItem).toHaveBeenCalledWith(dummyCreateTaskRequest);
+
+    expect(getTaskItemById).toHaveBeenCalledTimes(1);
+    expect(getTaskItemById).toHaveBeenCalledWith(invalidTaskId);
+  });
+});

--- a/functions/tests/small/usecases/create-task-usecase.test.ts
+++ b/functions/tests/small/usecases/create-task-usecase.test.ts
@@ -12,43 +12,6 @@ import {
 jest.mock('../../../src/infrastructure/ddb/tasks-table');
 jest.mock('../../../src/domain/task');
 
-const dummyCreateTaskRequest: CreateTaskRequest = {
-  title: 'コーヒーを淹れる',
-  description: '濃いめで',
-};
-const dummyCreateTaskRequestWithoutDescription: CreateTaskRequest = {
-  title: 'コーヒーを淹れる',
-};
-
-const dummyTask: Task = {
-  id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
-  title: 'スーパーに買い物に行く',
-  completed: false,
-  description: '牛乳と卵を買う',
-  createdAt: '2021-06-22T14:24:02.071Z',
-  updatedAt: '2021-06-22T14:24:02.071Z',
-};
-const dummyTaskWithoutDescription: Task = {
-  id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
-  title: 'スーパーに買い物に行く',
-  completed: false,
-  description: '',
-  createdAt: '2021-06-22T14:24:02.071Z',
-  updatedAt: '2021-06-22T14:24:02.071Z',
-};
-
-const validTaskId = 'valid-task-id';
-
-const dummyTaskRecord: TaskItem = {
-  userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
-  taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
-  title: 'スーパーに買い物に行く',
-  completed: false,
-  description: '牛乳と卵を買う',
-  createdAt: '2021-06-22T14:24:02.071Z',
-  updatedAt: '2021-06-22T14:24:02.071Z',
-};
-
 describe('createTaskUseCase', () => {
   beforeEach(() => {
     (createTaskItem as jest.Mock).mockClear();
@@ -56,13 +19,50 @@ describe('createTaskUseCase', () => {
     (toTask as jest.Mock).mockClear();
   });
 
+  const dummyCreateTaskRequest: CreateTaskRequest = {
+    title: 'コーヒーを淹れる',
+    description: '濃いめで',
+  };
+  const dummyCreateTaskRequestWithoutDescription: CreateTaskRequest = {
+    title: 'コーヒーを淹れる',
+  };
+
+  const dummyTask: Task = {
+    id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    description: '牛乳と卵を買う',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+  const dummyTaskWithoutDescription: Task = {
+    id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    description: '',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+
+  const validTaskId = 'valid-task-id';
+
+  const dummyTaskItem: TaskItem = {
+    userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+    taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+    title: 'スーパーに買い物に行く',
+    completed: false,
+    description: '牛乳と卵を買う',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+
   test.each`
     request                                     | task
     ${dummyCreateTaskRequest}                   | ${dummyTask}
     ${dummyCreateTaskRequestWithoutDescription} | ${dummyTaskWithoutDescription}
   `('should create a task successfully', async ({ request, task }) => {
     (createTaskItem as jest.Mock).mockResolvedValue(validTaskId);
-    (getTaskItemById as jest.Mock).mockResolvedValue(dummyTaskRecord);
+    (getTaskItemById as jest.Mock).mockResolvedValue(dummyTaskItem);
     (toTask as jest.Mock).mockReturnValue(task);
 
     const result = await createTaskUseCase(request);
@@ -74,12 +74,12 @@ describe('createTaskUseCase', () => {
     expect(getTaskItemById).toHaveBeenCalledWith(validTaskId);
 
     expect(toTask).toHaveBeenCalledTimes(1);
-    expect(toTask).toHaveBeenCalledWith(dummyTaskRecord);
+    expect(toTask).toHaveBeenCalledWith(dummyTaskItem);
 
     expect(result).toEqual(task);
   });
 
-  test('should throw AppError with TASK_NOT_FOUND if task record is not found', async () => {
+  test('should throw AppError with TASK_NOT_FOUND if task item is not found', async () => {
     const invalidTaskId = 'invalid-task-id';
 
     (createTaskItem as jest.Mock).mockResolvedValue(invalidTaskId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
+        "@types/uuid": "^9.0.2",
         "aws-sdk-client-mock": "^3.0.0"
       }
     },
@@ -2651,6 +2652,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {


### PR DESCRIPTION
## 対応内容

- タスク作成APIの実装
- handlerの定型処理であるバリデーションを切り出して共通化

## やらないこと

- APIドキュメントの更新
  - 見直したいポイントが多いので別PRで対応する