### PR TITLE
全テスト実行時にはlintも実行するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
-      - name: Test
-        run: npm test
+      - name: Small Test
+        run: npm test:small
+      - name: Medium Test
+        run: npm test:medium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Small Test
-        run: npm test:small
+        run: npm run test:s
       - name: Medium Test
-        run: npm test:medium
+        run: npm run test:m

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:s && npm run test:m",
+    "test": "npm run lint && npm run test:s && npm run test:m",
     "test:s": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest --testPathPattern=/functions/tests/small/",
     "test:m": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest --runInBand --testPathPattern=/functions/tests/medium/",
     "test:path": "dotenv -e ./functions/tests/.env.test -- ts-node node_modules/.bin/jest --",


### PR DESCRIPTION
## 対応内容

- `npm test`で全テストを行う場合にはLintも実行するように変更
    - LInt忘れでCIが落ちることが多いため
    - CIでは Small TestとMedium Testで分けて実行するように変更