### PR TITLE
taskRecordという文言をtaskItemに変更

### DIFF
--- a/functions/src/domain/task.ts
+++ b/functions/src/domain/task.ts
@@ -27,6 +27,6 @@ export const toTask = (item: TaskItem): Task => {
   try {
     return TaskSchema.parse(interimTask);
   } catch (error) {
-    throw new TaskConversionError('Failed to convert TaskRecord to Task');
+    throw new TaskConversionError('Failed to convert TaskItem to Task');
   }
 };

--- a/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/tasks-table.test.ts
@@ -63,7 +63,7 @@ describe('getTaskItemById', () => {
     updatedAt: '2021-06-22T14:24:02.071Z',
   };
 
-  test('should return the dummy task item by task ID', async () => {
+  test('should return the TaskItem by correct task ID', async () => {
     const TaskItem = await getTaskItemById(dummyTaskItem.taskId);
     expect(TaskItem).toEqual(dummyTaskItem);
   });

--- a/functions/tests/small/infrastructure/ddb/tasks-table.test.ts
+++ b/functions/tests/small/infrastructure/ddb/tasks-table.test.ts
@@ -78,7 +78,7 @@ describe('getTaskItemById', () => {
 
   const dummyTaskId = '1a7244c5-06d3-47e2-560e-f0b5534c8246';
 
-  test('should return a task record for a valid task ID', async () => {
+  test('should return a TaskItem for a valid task ID', async () => {
     const dummyTaskItem: TaskItem = {
       userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
       taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
@@ -114,11 +114,11 @@ describe('getTaskItemById', () => {
   });
 
   test('should throw an error if the retrieved item does not match the schema', async () => {
-    const invalidTaskRecord = {
+    const invalidTaskItem = {
       invalidField: 'invalidValue',
     };
 
-    documentMockClient.on(GetCommand).resolves({ Item: invalidTaskRecord });
+    documentMockClient.on(GetCommand).resolves({ Item: invalidTaskItem });
     await expect(getTaskItemById(dummyTaskId)).rejects.toThrow(
       DdbInternalServerError,
     );

--- a/functions/tests/small/usecases/create-task-usecase.test.ts
+++ b/functions/tests/small/usecases/create-task-usecase.test.ts
@@ -79,7 +79,7 @@ describe('createTaskUseCase', () => {
     expect(result).toEqual(task);
   });
 
-  test('should throw AppError with TASK_NOT_FOUND if task item is not found', async () => {
+  test('should throw AppError with TASK_NOT_FOUND if TaskItem is not found', async () => {
     const invalidTaskId = 'invalid-task-id';
 
     (createTaskItem as jest.Mock).mockResolvedValue(invalidTaskId);

--- a/functions/tests/small/usecases/get-task-usecase.test.ts
+++ b/functions/tests/small/usecases/get-task-usecase.test.ts
@@ -14,7 +14,7 @@ describe('getTask', () => {
 
   test('should return a task when it exists', async () => {
     const taskId = 'some-task-id';
-    const taskRecord: TaskItem = {
+    const dummyTaskItem: TaskItem = {
       userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
       taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
       title: 'スーパーに買い物に行く',
@@ -31,7 +31,7 @@ describe('getTask', () => {
       createdAt: '2021-06-22T14:24:02.071Z',
       updatedAt: '2021-06-22T14:24:02.071Z',
     };
-    (getTaskItemById as jest.Mock).mockResolvedValueOnce(taskRecord);
+    (getTaskItemById as jest.Mock).mockResolvedValueOnce(dummyTaskItem);
 
     const result = await getTaskUseCase(taskId);
 
@@ -51,12 +51,12 @@ describe('getTask', () => {
     expect(getTaskItemById).toHaveBeenCalledWith(taskId);
   });
 
-  test('should throw AppError with TASK_CONVERSION_ERROR when the task record cannot be converted to Task', async () => {
+  test('should throw AppError with TASK_CONVERSION_ERROR when the TaskItem cannot be converted to Task', async () => {
     const taskId = 'some-task-id';
-    const taskRecord = {
+    const invalidTaskItem = {
       invalidField: 'invalidValue',
     };
-    (getTaskItemById as jest.Mock).mockResolvedValueOnce(taskRecord);
+    (getTaskItemById as jest.Mock).mockResolvedValueOnce(invalidTaskItem);
 
     await expect(getTaskUseCase(taskId)).rejects.toThrowError(
       new AppError(ErrorCode.TASK_CONVERSION_ERROR),


### PR DESCRIPTION
以前のリファクタリングの際に古い名前のままだった変数名やメッセージを修正
- https://github.com/ky0yk/einoji/pull/9