### PR TITLE
タスク更新APIの実装

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -299,53 +299,53 @@ components:
               $ref: '#/components/examples/INVALID_PAYLOAD_FORMAT'
             INVALID_PATH_PARAMETER:
               $ref: '#/components/examples/INVALID_PATH_PARAMETER'
-      Common404:
-        description: 'Not Found'
-        content:
-          application/json:
-            schema:
-              type: 'object'
-              properties:
-                code:
-                  type: 'string'
-                  enum: [TASK_NOT_FOUND]
-                message:
-                  type: 'string'
-            examples:
-              TASK_NOT_FOUND:
-                $ref: '#/components/examples/TASK_NOT_FOUND'
-      Common422:
-        description: 'Unprocessable Entity'
-        content:
-          application/json:
-            schema:
-              type: 'object'
-              properties:
-                code:
-                  type: 'string'
-                  enum: [INVALID_PAYLOAD_VALUE]
-                message:
-                  type: 'string'
-            examples:
-              INVALID_PAYLOAD_VALUE:
-                $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
-      422PaylodAndUpdateRule:
-        description: 'Unprocessable Entity'
-        content:
-          application/json:
-            schema:
-              type: 'object'
-              properties:
-                code:
-                  type: 'string'
-                  enum: [INVALID_PAYLOAD_VALUE, TASK_UPDATE_RULE_ERROR]
-                message:
-                  type: 'string'
-            examples:
-              INVALID_PAYLOAD_VALUE:
-                $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
-              TASK_UPDATE_RULE_ERROR:
-                $ref: '#/components/examples/TASK_UPDATE_RULE_ERROR'
+    Common404:
+      description: 'Not Found'
+      content:
+        application/json:
+          schema:
+            type: 'object'
+            properties:
+              code:
+                type: 'string'
+                enum: [TASK_NOT_FOUND]
+              message:
+                type: 'string'
+          examples:
+            TASK_NOT_FOUND:
+              $ref: '#/components/examples/TASK_NOT_FOUND'
+    Common422:
+      description: 'Unprocessable Entity'
+      content:
+        application/json:
+          schema:
+            type: 'object'
+            properties:
+              code:
+                type: 'string'
+                enum: [INVALID_PAYLOAD_VALUE]
+              message:
+                type: 'string'
+          examples:
+            INVALID_PAYLOAD_VALUE:
+              $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
+    422PaylodAndUpdateRule:
+      description: 'Unprocessable Entity'
+      content:
+        application/json:
+          schema:
+            type: 'object'
+            properties:
+              code:
+                type: 'string'
+                enum: [INVALID_PAYLOAD_VALUE, TASK_UPDATE_RULE_ERROR]
+              message:
+                type: 'string'
+          examples:
+            INVALID_PAYLOAD_VALUE:
+              $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
+            TASK_UPDATE_RULE_ERROR:
+              $ref: '#/components/examples/TASK_UPDATE_RULE_ERROR'
     Common500:
       description: 'Internal Server Error'
       content:

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -39,26 +39,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Task'
         '400':
-          description: 'Bad Request'
-          content:
-            application/json:
-              schema:
-                type: 'object'
-                properties:
-                  code:
-                    type: 'string'
-                    enum: [INVALID_PAYLOAD]
-                  message:
-                    type: 'string'
-              examples:
-                INVALID_PAYLOAD_FORMAT:
-                  $ref: '#/components/examples/INVALID_PAYLOAD_FORMAT'
-                INVALID_PAYLOAD_VALUE:
-                  $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
-        '500':
-          $ref: '#/components/responses/Common500'
-        '503':
-          $ref: '#/components/responses/Common503'
+          $ref: '#/components/responses/400Path'
+        '422':
+          $ref: '#/components/responses/Common422'
 
   /tasks/{id}:
     get:
@@ -125,6 +108,8 @@ paths:
           $ref: '#/components/responses/400PathAndPayload'
         '404':
           $ref: '#/components/responses/Common404'
+        '422':
+          $ref: '#/components/responses/422PaylodAndUpdateRule'
         '500':
           $ref: '#/components/responses/Common500'
         '503':
@@ -178,6 +163,8 @@ paths:
           $ref: '#/components/responses/400PathAndPayload'
         '404':
           $ref: '#/components/responses/Common404'
+        '422':
+          $ref: '#/components/responses/422PaylodAndUpdateRule'
         '500':
           $ref: '#/components/responses/Common500'
         '503':
@@ -280,8 +267,8 @@ components:
           type: string
 
   responses:
-    Common404:
-      description: 'Not Found'
+    400Path:
+      description: 'Bad Request'
       content:
         application/json:
           schema:
@@ -289,12 +276,76 @@ components:
             properties:
               code:
                 type: 'string'
-                enum: [TASK_NOT_FOUND]
+                enum: [INVALID_PATH_PARAMETER]
               message:
                 type: 'string'
           examples:
-            TASK_NOT_FOUND:
-              $ref: '#/components/examples/TASK_NOT_FOUND'
+            INVALID_PATH_PARAMETER:
+              $ref: '#/components/examples/INVALID_PATH_PARAMETER'
+    400PathAndPayload:
+      description: 'Bad Request'
+      content:
+        application/json:
+          schema:
+            type: 'object'
+            properties:
+              code:
+                type: 'string'
+                enum: [INVALID_PAYLOAD_FORMAT, INVALID_PATH_PARAMETER]
+              message:
+                type: 'string'
+          examples:
+            INVALID_PAYLOAD_FORMAT:
+              $ref: '#/components/examples/INVALID_PAYLOAD_FORMAT'
+            INVALID_PATH_PARAMETER:
+              $ref: '#/components/examples/INVALID_PATH_PARAMETER'
+      Common404:
+        description: 'Not Found'
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                code:
+                  type: 'string'
+                  enum: [TASK_NOT_FOUND]
+                message:
+                  type: 'string'
+            examples:
+              TASK_NOT_FOUND:
+                $ref: '#/components/examples/TASK_NOT_FOUND'
+      Common422:
+        description: 'Unprocessable Entity'
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                code:
+                  type: 'string'
+                  enum: [INVALID_PAYLOAD_VALUE]
+                message:
+                  type: 'string'
+            examples:
+              INVALID_PAYLOAD_VALUE:
+                $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
+      422PaylodAndUpdateRule:
+        description: 'Unprocessable Entity'
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                code:
+                  type: 'string'
+                  enum: [INVALID_PAYLOAD_VALUE, TASK_UPDATE_RULE_ERROR]
+                message:
+                  type: 'string'
+            examples:
+              INVALID_PAYLOAD_VALUE:
+                $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
+              TASK_UPDATE_RULE_ERROR:
+                $ref: '#/components/examples/TASK_UPDATE_RULE_ERROR'
     Common500:
       description: 'Internal Server Error'
       content:
@@ -331,45 +382,6 @@ components:
               $ref: '#/components/examples/SERVICE_DOWNTIME'
             EXTERNAL_SERVICE_FAILURE:
               $ref: '#/components/examples/EXTERNAL_SERVICE_FAILURE'
-    400Path:
-      description: 'Bad Request'
-      content:
-        application/json:
-          schema:
-            type: 'object'
-            properties:
-              code:
-                type: 'string'
-                enum: [INVALID_PATH_PARAMETER]
-              message:
-                type: 'string'
-          examples:
-            INVALID_PATH_PARAMETER:
-              $ref: '#/components/examples/INVALID_PATH_PARAMETER'
-    400PathAndPayload:
-      description: 'Bad Request'
-      content:
-        application/json:
-          schema:
-            type: 'object'
-            properties:
-              code:
-                type: 'string'
-                enum:
-                  [
-                    INVALID_PAYLOAD_FORMAT,
-                    INVALID_PAYLOAD_VALUE,
-                    INVALID_PATH_PARAMETER,
-                  ]
-              message:
-                type: 'string'
-          examples:
-            INVALID_PAYLOAD_FORMAT:
-              $ref: '#/components/examples/INVALID_PAYLOAD_FORMAT'
-            INVALID_PAYLOAD_VALUE:
-              $ref: '#/components/examples/INVALID_PAYLOAD_VALUE'
-            INVALID_PATH_PARAMETER:
-              $ref: '#/components/examples/INVALID_PATH_PARAMETER'
 
   examples:
     INVALID_PAYLOAD_FORMAT:
@@ -392,6 +404,10 @@ components:
       value:
         code: 'APP001'
         message: 'Task not found. TaskID: ${taskId}'
+    TASK_UPDATE_RULE_ERROR:
+      value:
+        code: 'APP002'
+        message: 'Provided data does not follow update rules.'
     DATABASE_CONNECTION_ERROR:
       value:
         code: 'SYS001'

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -42,6 +42,10 @@ paths:
           $ref: '#/components/responses/400Path'
         '422':
           $ref: '#/components/responses/Common422'
+        '500':
+          $ref: '#/components/responses/Common500'
+        '503':
+          $ref: '#/components/responses/Common503'
 
   /tasks/{id}:
     get:

--- a/functions/src/common/errors/error-codes.ts
+++ b/functions/src/common/errors/error-codes.ts
@@ -9,6 +9,7 @@ export enum ErrorCode {
 
   // アプリケーション例外（回復可）
   TASK_NOT_FOUND = 'APP001', // 存在しないTODOのIDでの操作
+  TASK_UPDATE_RULE_ERROR = 'APP002', // TODOの更新ルール違反
 
   // アプリケーション例外（回復不可） 必要になったらAPP101から始める
 
@@ -27,6 +28,7 @@ export const errorCodetoStatus = (errorCode: ErrorCode): HttpStatus => {
       return HttpStatus.BAD_REQUEST;
 
     case ErrorCode.INVALID_PAYLOAD_VALUE:
+    case ErrorCode.TASK_UPDATE_RULE_ERROR:
       return HttpStatus.UNPROCESSABLE_ENTITY;
 
     case ErrorCode.TASK_NOT_FOUND:

--- a/functions/src/domain/errors/task-errors.ts
+++ b/functions/src/domain/errors/task-errors.ts
@@ -12,3 +12,8 @@ export class TaskNotFoundError extends TaskError {
     super(message, originalError);
   }
 }
+export class TaskUpdateRuleError extends TaskError {
+  constructor(message: string, originalError?: Error) {
+    super(message, originalError);
+  }
+}

--- a/functions/src/domain/task.ts
+++ b/functions/src/domain/task.ts
@@ -16,3 +16,7 @@ export type CreateTaskData = {
   title: string;
   description?: string;
 };
+export type UpdateTaskData = {
+  title?: string;
+  description?: string;
+};

--- a/functions/src/handlers/schemas/task-requests.ts
+++ b/functions/src/handlers/schemas/task-requests.ts
@@ -9,3 +9,15 @@ export const CreateTaskRequestSchema = z.object({
   description: z.string().max(1000).optional(),
 });
 export type CreateTaskRequest = z.infer<typeof CreateTaskRequestSchema>;
+
+export const UpdateTaskRequestSchema = z
+  .object({
+    title: z.string().min(1).max(100).optional(),
+    description: z.string().max(1000).optional(),
+  })
+  .transform((data) => {
+    return Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined),
+    );
+  });
+export type UpdateTaskRequest = z.infer<typeof UpdateTaskRequestSchema>;

--- a/functions/src/handlers/update-task-handler.ts
+++ b/functions/src/handlers/update-task-handler.ts
@@ -1,0 +1,32 @@
+import { APIGatewayEvent } from 'aws-lambda';
+import {
+  RequestHandlerWithoutContext,
+  handlerFactory,
+} from './factory/handler-factory';
+import { LambdaResponse, httpResponse } from './http/http-response';
+import { HttpStatus } from './http/http-status';
+import {
+  TaskIdPathParamsSchema,
+  UpdateTaskRequestSchema,
+} from './schemas/task-requests';
+import { updateTaskUsecase } from '../usecases/update-task-usecase';
+import { validateBodyAndPathParams } from './http/validators';
+
+const requestHandler: RequestHandlerWithoutContext = async (
+  event: APIGatewayEvent,
+): Promise<LambdaResponse> => {
+  const {
+    body: updateTaskData,
+    pathParameters: { id: taskId },
+  } = validateBodyAndPathParams(
+    event,
+    UpdateTaskRequestSchema,
+    TaskIdPathParamsSchema,
+  );
+
+  const updatedTask = await updateTaskUsecase(taskId, updateTaskData);
+
+  return httpResponse(HttpStatus.OK).withBody(updatedTask);
+};
+
+export const handler = handlerFactory('updateTask', requestHandler);

--- a/functions/src/infrastructure/ddb/task-repository.ts
+++ b/functions/src/infrastructure/ddb/task-repository.ts
@@ -16,7 +16,7 @@ import {
   CreateTaskPayload,
   GetTaskCommand,
   TaskRepository,
-  TaskUpdateAtLeastOne,
+  UpdateTaskAtLeastOne,
   UpdateTaskCommand,
 } from '../../usecases/contracts/task-repository-contract';
 import { Task } from '../../domain/task';
@@ -88,7 +88,7 @@ const getTaskItemByIdImpl: GetTaskCommand = async (
 
 const updateTaskItemByIdImpl: UpdateTaskCommand = async (
   taskId: string,
-  data: TaskUpdateAtLeastOne,
+  data: UpdateTaskAtLeastOne,
 ): Promise<Task> => {
   const now = new Date().toISOString();
 

--- a/functions/src/usecases/contracts/task-repository-contract.ts
+++ b/functions/src/usecases/contracts/task-repository-contract.ts
@@ -4,13 +4,28 @@ export type RepoCommand<T, P extends unknown[]> = (...args: P) => Promise<T>;
 
 export type CreateTaskCommand = RepoCommand<string, [CreateTaskPayload]>;
 export type GetTaskCommand = RepoCommand<Task | null, [string]>;
+export type UpdateTaskCommand = RepoCommand<
+  Task,
+  [string, TaskUpdateAtLeastOne]
+>;
 
 export type TaskRepository = {
   create: CreateTaskCommand;
   getById: GetTaskCommand;
+  update: UpdateTaskCommand;
 };
 
 export type CreateTaskPayload = {
   title: string;
   description?: string;
 };
+
+type UpdateTaskPayload = {
+  title: string;
+  description: string;
+};
+
+type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> &
+  U[keyof U];
+
+export type TaskUpdateAtLeastOne = AtLeastOne<UpdateTaskPayload>;

--- a/functions/src/usecases/contracts/task-repository-contract.ts
+++ b/functions/src/usecases/contracts/task-repository-contract.ts
@@ -6,7 +6,7 @@ export type CreateTaskCommand = RepoCommand<string, [CreateTaskPayload]>;
 export type GetTaskCommand = RepoCommand<Task | null, [string]>;
 export type UpdateTaskCommand = RepoCommand<
   Task,
-  [string, TaskUpdateAtLeastOne]
+  [string, UpdateTaskAtLeastOne]
 >;
 
 export type TaskRepository = {
@@ -28,4 +28,4 @@ type UpdateTaskPayload = {
 type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> &
   U[keyof U];
 
-export type TaskUpdateAtLeastOne = AtLeastOne<UpdateTaskPayload>;
+export type UpdateTaskAtLeastOne = AtLeastOne<UpdateTaskPayload>;

--- a/functions/src/usecases/factory/usecase-error-handler.ts
+++ b/functions/src/usecases/factory/usecase-error-handler.ts
@@ -1,6 +1,10 @@
 import { AppError } from '../../common/errors/app-errors';
 import { ErrorCode } from '../../common/errors/error-codes';
-import { TaskError, TaskNotFoundError } from '../../domain/errors/task-errors';
+import {
+  TaskError,
+  TaskNotFoundError,
+  TaskUpdateRuleError,
+} from '../../domain/errors/task-errors';
 import {
   DdbError,
   DdbInternalServerError,
@@ -26,6 +30,9 @@ export const useCaseErrorHandler = (error: DdbError | TaskError): AppError => {
   }
   if (error instanceof TaskNotFoundError) {
     return new AppError(ErrorCode.TASK_NOT_FOUND, error.message, error);
+  }
+  if (error instanceof TaskUpdateRuleError) {
+    return new AppError(ErrorCode.TASK_UPDATE_RULE_ERROR, error.message, error);
   }
   return new AppError(ErrorCode.UNKNOWN_ERROR, error.message, error);
 };

--- a/functions/src/usecases/update-task-usecase.ts
+++ b/functions/src/usecases/update-task-usecase.ts
@@ -1,0 +1,24 @@
+import { TaskUpdateRuleError } from '../domain/errors/task-errors';
+import { Task, UpdateTaskData } from '../domain/task';
+import { taskRepository } from '../infrastructure/ddb/task-repository';
+import { TaskUpdateAtLeastOne } from './contracts/task-repository-contract';
+import { useCaseFactory } from './factory/usecase-factory';
+
+const updateTask = async (
+  taskId: string,
+  data: UpdateTaskData,
+): Promise<Task> => {
+  if (isEmpty(data)) {
+    throw new TaskUpdateRuleError(
+      'Provided data does not follow update rules.',
+    );
+  }
+
+  return await taskRepository.update(taskId, data as TaskUpdateAtLeastOne);
+};
+
+const isEmpty = (obj: object): boolean => {
+  return Object.keys(obj).length === 0;
+};
+
+export const updateTaskUsecase = useCaseFactory('updateTask', updateTask);

--- a/functions/src/usecases/update-task-usecase.ts
+++ b/functions/src/usecases/update-task-usecase.ts
@@ -1,7 +1,7 @@
 import { TaskUpdateRuleError } from '../domain/errors/task-errors';
 import { Task, UpdateTaskData } from '../domain/task';
 import { taskRepository } from '../infrastructure/ddb/task-repository';
-import { TaskUpdateAtLeastOne } from './contracts/task-repository-contract';
+import { UpdateTaskAtLeastOne } from './contracts/task-repository-contract';
 import { useCaseFactory } from './factory/usecase-factory';
 
 const updateTask = async (
@@ -14,7 +14,7 @@ const updateTask = async (
     );
   }
 
-  return await taskRepository.update(taskId, data as TaskUpdateAtLeastOne);
+  return await taskRepository.update(taskId, data as UpdateTaskAtLeastOne);
 };
 
 const isEmpty = (obj: object): boolean => {

--- a/functions/tests/medium/infrastructure/ddb/task-repository.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/task-repository.test.ts
@@ -9,7 +9,7 @@ import {
   deleteTask,
   putTask,
 } from '../../../helpers/task-repository-helpers';
-describe('createTaskItem', () => {
+describe('taskRepository.create', () => {
   beforeAll(async () => {
     await createTable();
   });
@@ -38,7 +38,7 @@ describe('createTaskItem', () => {
   });
 });
 
-describe('getTaskItemById', () => {
+describe('taskRepository.getById', () => {
   beforeAll(async () => {
     await createTable();
   });
@@ -79,5 +79,68 @@ describe('getTaskItemById', () => {
 
     const TaskItem = await taskRepository.getById(nonExistentTaskId);
     expect(TaskItem).toBeNull();
+  });
+});
+
+describe('taskRepository.update', () => {
+  beforeAll(async () => {
+    await createTable();
+  });
+
+  afterAll(async () => {
+    await deleteTable();
+  });
+
+  describe('update', () => {
+    const originalTaskItem: TaskItem = {
+      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
+      taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+      title: 'スーパーに買い物に行く',
+      completed: false,
+      description: '牛乳と卵を買う',
+      createdAt: '2021-06-22T14:24:02.071Z',
+      updatedAt: '2021-06-22T14:24:02.071Z',
+    };
+
+    beforeEach(async () => {
+      await putTask(originalTaskItem);
+    });
+
+    afterEach(async () => {
+      await deleteTask(originalTaskItem.taskId);
+    });
+
+    test('should update a task successfully when provided with both title and description', async () => {
+      const updateData = {
+        title: '新しいタイトル',
+        description: '新しい説明',
+      };
+
+      await taskRepository.update(originalTaskItem.taskId, updateData);
+
+      const updatedTask = await taskRepository.getById(originalTaskItem.taskId);
+      if (!updatedTask) {
+        throw new Error('Updated task not found');
+      }
+
+      expect(updatedTask.title).toEqual(updateData.title);
+      expect(updatedTask.description).toEqual(updateData.description);
+    });
+
+    test('should update a task successfully when provided only with title', async () => {
+      const updateData = {
+        title: '新しいタイトルのみ',
+      };
+
+      await taskRepository.update(originalTaskItem.taskId, updateData);
+
+      const updatedTask = await taskRepository.getById(originalTaskItem.taskId);
+      if (!updatedTask) {
+        throw new Error('Updated task not found');
+      }
+
+      expect(updatedTask.title).toEqual(updateData.title);
+      expect(updatedTask.description).toEqual(originalTaskItem.description);
+    });
   });
 });

--- a/functions/tests/small/handlers/update-task-handler.test.ts
+++ b/functions/tests/small/handlers/update-task-handler.test.ts
@@ -1,0 +1,152 @@
+import { Task } from '../../../src/domain/task';
+import { updateTaskUsecase } from '../../../src/usecases/update-task-usecase';
+import { APIGatewayEvent, Context } from 'aws-lambda';
+import { handler } from '../../../src/handlers/update-task-handler';
+import { ErrorCode } from '../../../src/common/errors/error-codes';
+
+jest.mock('../../../src/usecases/update-task-usecase');
+
+describe('Update Task Request Handler', () => {
+  beforeEach(() => {
+    (updateTaskUsecase as jest.Mock).mockClear();
+  });
+
+  const taskId = 'f0f8f5a0-309d-11ec-8d3d-0242ac130003';
+  const dummyTaskWithDescription: Task = {
+    id: taskId,
+    title: 'スーパーに買い物に行くの更新',
+    completed: false,
+    description: '牛乳と卵を買うの更新',
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
+  };
+
+  const dummyTaskWithoutDescription: Task = {
+    ...dummyTaskWithDescription,
+    description: undefined,
+  };
+
+  const updateReqWithDescription = {
+    title: dummyTaskWithDescription.title,
+    description: dummyTaskWithDescription.description,
+  };
+
+  const updateReqWithoutDescription = {
+    title: dummyTaskWithDescription.title,
+  };
+
+  const updateReqWithoutTitle = {
+    description: dummyTaskWithDescription.description,
+  };
+
+  const dummyContext = {} as Context;
+
+  describe('For a valid request', () => {
+    const validCases = [
+      {
+        request: {
+          body: JSON.stringify(updateReqWithDescription),
+          pathParameters: { id: taskId },
+        } as unknown as APIGatewayEvent,
+        body: updateReqWithDescription,
+        expectedTask: dummyTaskWithDescription,
+        description: 'with title and description',
+      },
+      {
+        request: {
+          body: JSON.stringify(updateReqWithoutDescription),
+          pathParameters: { id: taskId },
+        } as unknown as APIGatewayEvent,
+        body: updateReqWithoutDescription,
+        expectedTask: dummyTaskWithoutDescription,
+        description: 'with only title',
+      },
+      {
+        request: {
+          body: JSON.stringify(updateReqWithoutTitle),
+          pathParameters: { id: taskId },
+        } as unknown as APIGatewayEvent,
+        body: updateReqWithoutTitle,
+        expectedTask: dummyTaskWithoutDescription,
+        description: 'with only description',
+      },
+    ];
+
+    validCases.forEach(({ request, body, expectedTask, description }) => {
+      test(`should return 200 ${description}`, async () => {
+        (updateTaskUsecase as jest.Mock).mockResolvedValueOnce(expectedTask);
+
+        const result = await handler(request, dummyContext);
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body!)).toEqual(expectedTask);
+        expect(updateTaskUsecase).toHaveBeenCalledTimes(1);
+        expect(updateTaskUsecase).toHaveBeenCalledWith(taskId, body);
+      });
+    });
+  });
+
+  describe('For an invalid request format', () => {
+    const invalidFormatCases = [
+      {
+        request: {
+          body: JSON.stringify(null),
+          pathParameters: { id: taskId },
+        } as unknown as APIGatewayEvent,
+        expectedErrorCode: ErrorCode.INVALID_PAYLOAD_FORMAT,
+        situation: 'body is null',
+      },
+      {
+        request: {
+          body: JSON.stringify(updateReqWithDescription),
+        } as unknown as APIGatewayEvent,
+        expectedErrorCode: ErrorCode.INVALID_PATH_PARAMETER,
+        situation: 'path parameter is missing',
+      },
+    ];
+
+    invalidFormatCases.forEach(({ request, expectedErrorCode, situation }) => {
+      test(`should return 400 with INVALID_PAYLOAD_FORMAT when ${situation}`, async () => {
+        const result = await handler(request, dummyContext);
+        expect(result.statusCode).toBe(400);
+        expect(JSON.parse(result.body!).code).toBe(expectedErrorCode);
+        expect(updateTaskUsecase).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('For an invalid payload value but valid request format', () => {
+    const invalidValueCases = [
+      {
+        request: {
+          body: JSON.stringify({
+            title: 'a'.repeat(101),
+            description: dummyTaskWithDescription.description,
+          }),
+          pathParameters: { id: taskId },
+        } as unknown as APIGatewayEvent,
+        situation: 'title has 101 characters',
+      },
+      {
+        request: {
+          body: JSON.stringify({
+            title: dummyTaskWithDescription.title,
+            description: 'a'.repeat(1001),
+          }),
+          pathParameters: { id: taskId },
+        } as unknown as APIGatewayEvent,
+        situation: 'description has 1001 characters',
+      },
+    ];
+
+    invalidValueCases.forEach(({ request, situation }) => {
+      test(`should return 422 with INVALID_PAYLOAD_VALUE but correct format when ${situation}`, async () => {
+        const result = await handler(request, dummyContext);
+        expect(result.statusCode).toBe(422);
+        expect(JSON.parse(result.body!).code).toBe(
+          ErrorCode.INVALID_PAYLOAD_VALUE,
+        );
+        expect(updateTaskUsecase).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/functions/tests/small/handlers/update-task-handler.test.ts
+++ b/functions/tests/small/handlers/update-task-handler.test.ts
@@ -12,31 +12,35 @@ describe('Update Task Request Handler', () => {
   });
 
   const taskId = 'f0f8f5a0-309d-11ec-8d3d-0242ac130003';
+
   const dummyTaskWithDescription: Task = {
     id: taskId,
-    title: 'スーパーに買い物に行くの更新',
+    title: 'スーパーで買い物',
     completed: false,
-    description: '牛乳と卵を買うの更新',
+    description: '牛乳と卵を買う',
     createdAt: '2021-06-22T14:24:02.071Z',
     updatedAt: '2021-06-22T14:24:02.071Z',
   };
 
   const dummyTaskWithoutDescription: Task = {
-    ...dummyTaskWithDescription,
-    description: undefined,
+    id: taskId,
+    title: 'スーパーで買い物',
+    completed: false,
+    createdAt: '2021-06-22T14:24:02.071Z',
+    updatedAt: '2021-06-22T14:24:02.071Z',
   };
 
   const updateReqWithDescription = {
-    title: dummyTaskWithDescription.title,
-    description: dummyTaskWithDescription.description,
+    title: '図書館で本を借りる',
+    description: 'ミステリー小説と料理の本を探す',
   };
 
   const updateReqWithoutDescription = {
-    title: dummyTaskWithDescription.title,
+    title: '図書館で本を借りる',
   };
 
   const updateReqWithoutTitle = {
-    description: dummyTaskWithDescription.description,
+    description: 'ミステリー小説と料理の本を探す',
   };
 
   const dummyContext = {} as Context;
@@ -50,7 +54,7 @@ describe('Update Task Request Handler', () => {
         } as unknown as APIGatewayEvent,
         body: updateReqWithDescription,
         expectedTask: dummyTaskWithDescription,
-        description: 'with title and description',
+        situation: 'with title and description',
       },
       {
         request: {
@@ -59,7 +63,7 @@ describe('Update Task Request Handler', () => {
         } as unknown as APIGatewayEvent,
         body: updateReqWithoutDescription,
         expectedTask: dummyTaskWithoutDescription,
-        description: 'with only title',
+        situation: 'with only title',
       },
       {
         request: {
@@ -68,12 +72,12 @@ describe('Update Task Request Handler', () => {
         } as unknown as APIGatewayEvent,
         body: updateReqWithoutTitle,
         expectedTask: dummyTaskWithoutDescription,
-        description: 'with only description',
+        situation: 'with only description',
       },
     ];
 
-    validCases.forEach(({ request, body, expectedTask, description }) => {
-      test(`should return 200 ${description}`, async () => {
+    validCases.forEach(({ request, body, expectedTask, situation }) => {
+      test(`should return 200 ${situation}`, async () => {
         (updateTaskUsecase as jest.Mock).mockResolvedValueOnce(expectedTask);
 
         const result = await handler(request, dummyContext);

--- a/functions/tests/small/infrastructure/ddb/task-repository.test.ts
+++ b/functions/tests/small/infrastructure/ddb/task-repository.test.ts
@@ -159,7 +159,7 @@ describe('taskRepository.update', () => {
         updatedAt: updatedAt,
       },
       expectedUpdateExpression:
-        'set #title = :title, #description = :description, #updatedAt = :updatedAt',
+        'SET #title = :title, #description = :description, #updatedAt = :updatedAt',
       expectedExpressionAttributeNames: {
         '#title': 'title',
         '#description': 'description',
@@ -193,7 +193,7 @@ describe('taskRepository.update', () => {
         createdAt: '2021-06-22T14:24:02.071Z',
         updatedAt: updatedAt,
       },
-      expectedUpdateExpression: 'set #title = :title, #updatedAt = :updatedAt',
+      expectedUpdateExpression: 'SET #title = :title, #updatedAt = :updatedAt',
       expectedExpressionAttributeNames: {
         '#title': 'title',
         '#updatedAt': 'updatedAt',

--- a/functions/tests/small/usecases/factory/usecase-error-handler.test.ts
+++ b/functions/tests/small/usecases/factory/usecase-error-handler.test.ts
@@ -1,7 +1,10 @@
 import { AppError } from '../../../../src/common/errors/app-errors';
 import { ErrorCode } from '../../../../src/common/errors/error-codes';
 
-import { TaskNotFoundError } from '../../../../src/domain/errors/task-errors';
+import {
+  TaskNotFoundError,
+  TaskUpdateRuleError,
+} from '../../../../src/domain/errors/task-errors';
 import {
   DdbResourceNotFoundError,
   DdbProvisionedThroughputExceededError,
@@ -16,6 +19,7 @@ describe('useCaseErrorHandler', () => {
   test.each`
     error_instance                                                  | expected_error_code
     ${new TaskNotFoundError('')}                                    | ${ErrorCode.TASK_NOT_FOUND}
+    ${new TaskUpdateRuleError('')}                                  | ${ErrorCode.TASK_UPDATE_RULE_ERROR}
     ${new DdbResourceNotFoundError('', originalError)}              | ${ErrorCode.DATABASE_CONNECTION_ERROR}
     ${new DdbProvisionedThroughputExceededError('', originalError)} | ${ErrorCode.DATABASE_CONNECTION_ERROR}
     ${new DdbValidationError('', originalError)}                    | ${ErrorCode.INVALID_PAYLOAD_VALUE}

--- a/functions/tests/small/usecases/update-task-usecase.test.ts
+++ b/functions/tests/small/usecases/update-task-usecase.test.ts
@@ -1,0 +1,53 @@
+import { AppError } from '../../../src/common/errors/app-errors';
+import { ErrorCode } from '../../../src/common/errors/error-codes';
+import { Task } from '../../../src/domain/task';
+import { taskRepository } from '../../../src/infrastructure/ddb/task-repository';
+import { updateTaskUsecase } from '../../../src/usecases/update-task-usecase';
+
+jest.mock('../../../src/infrastructure/ddb/task-repository');
+
+describe('updateTaskUsecase', () => {
+  beforeEach(() => {
+    (taskRepository.update as jest.Mock).mockClear();
+  });
+
+  const validTaskId = 'valid-task-id';
+  const descriptionWithOnlyTitle = 'update with only title';
+  const descriptionWithTitleAndDesc = 'update with title and description';
+  const updateDataOnlyTitle = { title: 'スーパーに買い物に行くの更新' };
+  const updateDataWithTitleAndDesc = {
+    title: 'スーパーに買い物に行くの更新',
+    description: '牛乳と卵を買うの更新',
+  };
+
+  test.each`
+    description                    | updateData                    | expectedDescription
+    ${descriptionWithOnlyTitle}    | ${updateDataOnlyTitle}        | ${''}
+    ${descriptionWithTitleAndDesc} | ${updateDataWithTitleAndDesc} | ${'牛乳と卵を買うの更新'}
+  `('should $description', async ({ updateData, expectedDescription }) => {
+    const dummyUpdatedTask: Task = {
+      id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+      title: updateData.title,
+      completed: false,
+      description: expectedDescription || '',
+      createdAt: '2021-06-22T14:24:02.071Z',
+      updatedAt: '2021-06-22T14:24:02.071Z',
+    };
+
+    (taskRepository.update as jest.Mock).mockResolvedValue(dummyUpdatedTask);
+
+    const result = await updateTaskUsecase(validTaskId, updateData);
+
+    expect(taskRepository.update).toHaveBeenCalledTimes(1);
+    expect(taskRepository.update).toHaveBeenCalledWith(validTaskId, updateData);
+    expect(result).toEqual(dummyUpdatedTask);
+  });
+
+  test('should throw TaskUpdateRuleError if update data is empty', async () => {
+    const err = await updateTaskUsecase(validTaskId, {}).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.code).toEqual(ErrorCode.TASK_UPDATE_RULE_ERROR);
+    expect(taskRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/functions/tests/small/usecases/update-task-usecase.test.ts
+++ b/functions/tests/small/usecases/update-task-usecase.test.ts
@@ -12,38 +12,45 @@ describe('updateTaskUsecase', () => {
   });
 
   const validTaskId = 'valid-task-id';
-  const descriptionWithOnlyTitle = 'update with only title';
-  const descriptionWithTitleAndDesc = 'update with title and description';
-  const updateDataOnlyTitle = { title: 'スーパーに買い物に行くの更新' };
+  const situationWithOnlyTitle = 'update data contains only title';
+  const situationWithTitleAndDesc =
+    'update data contains both title and description';
+  const updateDataOnlyTitle = { title: '図書館で学習する' };
   const updateDataWithTitleAndDesc = {
-    title: 'スーパーに買い物に行くの更新',
-    description: '牛乳と卵を買うの更新',
+    title: '図書館で学習する',
+    description: '参考書とノートを持って行く',
   };
 
   test.each`
-    description                    | updateData                    | expectedDescription
-    ${descriptionWithOnlyTitle}    | ${updateDataOnlyTitle}        | ${''}
-    ${descriptionWithTitleAndDesc} | ${updateDataWithTitleAndDesc} | ${'牛乳と卵を買うの更新'}
-  `('should $description', async ({ updateData, expectedDescription }) => {
-    const dummyUpdatedTask: Task = {
-      id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
-      title: updateData.title,
-      completed: false,
-      description: expectedDescription || '',
-      createdAt: '2021-06-22T14:24:02.071Z',
-      updatedAt: '2021-06-22T14:24:02.071Z',
-    };
+    situation                    | updateData                    | expectedDescription
+    ${situationWithOnlyTitle}    | ${updateDataOnlyTitle}        | ${''}
+    ${situationWithTitleAndDesc} | ${updateDataWithTitleAndDesc} | ${'参考書とノートを持って行く'}
+  `(
+    'given $situation, should update appropriately',
+    async ({ updateData, expectedDescription }) => {
+      const dummyUpdatedTask: Task = {
+        id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
+        title: updateData.title,
+        completed: false,
+        description: expectedDescription || '',
+        createdAt: '2021-06-22T14:24:02.071Z',
+        updatedAt: '2021-06-22T14:24:02.071Z',
+      };
 
-    (taskRepository.update as jest.Mock).mockResolvedValue(dummyUpdatedTask);
+      (taskRepository.update as jest.Mock).mockResolvedValue(dummyUpdatedTask);
 
-    const result = await updateTaskUsecase(validTaskId, updateData);
+      const result = await updateTaskUsecase(validTaskId, updateData);
 
-    expect(taskRepository.update).toHaveBeenCalledTimes(1);
-    expect(taskRepository.update).toHaveBeenCalledWith(validTaskId, updateData);
-    expect(result).toEqual(dummyUpdatedTask);
-  });
+      expect(taskRepository.update).toHaveBeenCalledTimes(1);
+      expect(taskRepository.update).toHaveBeenCalledWith(
+        validTaskId,
+        updateData,
+      );
+      expect(result).toEqual(dummyUpdatedTask);
+    },
+  );
 
-  test('should throw TaskUpdateRuleError if update data is empty', async () => {
+  test('given update data is empty, should throw TaskUpdateRuleError', async () => {
     const err = await updateTaskUsecase(validTaskId, {}).catch((e) => e);
 
     expect(err).toBeInstanceOf(AppError);


### PR DESCRIPTION
## 対応内容

- API Docの修正
- タスク更新APIの実装
  - 複数引数を取れるようにユースケースのFactoryを修正
  - ドメイン系のエラーである`TaskUpdateRuleError`を追加
    - エラーハンドリングも終始絵