### PR TITLE
命名の見直し

### DIFF
--- a/functions/src/handlers/create-task-handler.ts
+++ b/functions/src/handlers/create-task-handler.ts
@@ -10,7 +10,7 @@ import { HttpStatus } from './http/http-status';
 import { validateBody } from './http/validators';
 import { CreateTaskData } from '../domain/task';
 
-const requestHandler: RequestHandlerWithoutContext = async (
+const createTaskHandler: RequestHandlerWithoutContext = async (
   event: APIGatewayEvent,
 ): Promise<LambdaResponse> => {
   const data: CreateTaskData = validateBody(CreateTaskRequestSchema, event);
@@ -20,4 +20,4 @@ const requestHandler: RequestHandlerWithoutContext = async (
   return httpResponse(HttpStatus.CREATED, createdTask);
 };
 
-export const handler = handlerFactory('createTask', requestHandler);
+export const handler = handlerFactory('createTask', createTaskHandler);

--- a/functions/src/handlers/delete-task-handler.ts
+++ b/functions/src/handlers/delete-task-handler.ts
@@ -9,7 +9,7 @@ import { TaskIdPathParamsSchema } from './schemas/task-requests';
 import { HttpStatus } from './http/http-status';
 import { deleteTaskUseCase } from '../usecases/delete-task-usecase';
 
-const requestHandler: RequestHandlerWithoutContext = async (
+const deleteTaskHandler: RequestHandlerWithoutContext = async (
   event: APIGatewayEvent,
 ): Promise<LambdaResponse> => {
   const { id: taskId } = validatePathParams(TaskIdPathParamsSchema, event);
@@ -17,4 +17,4 @@ const requestHandler: RequestHandlerWithoutContext = async (
   return httpResponse(HttpStatus.NO_CONTENT);
 };
 
-export const handler = handlerFactory('deleteTask', requestHandler);
+export const handler = handlerFactory('deleteTask', deleteTaskHandler);

--- a/functions/src/handlers/factory/handler-factory.ts
+++ b/functions/src/handlers/factory/handler-factory.ts
@@ -35,7 +35,7 @@ const requestHandlerWithLog = async (
   requestHandler: RequestHandlerWithoutContext,
   event: APIGatewayEvent,
 ): Promise<LambdaResponse> => {
-  logger.info(`START handler: ${name}`);
+  logger.info(`ENTRY handler: ${name}`);
   const result = await requestHandler(event);
   logger.info(`EXIT handler: ${name}`);
   return result;
@@ -48,7 +48,7 @@ const requestErrorHandlerWithLog = async (
 ): Promise<LambdaResponse> => {
   logger.error(`An error occurred in handler: ${name}`);
   if (e instanceof AppError) {
-    logger.error(`START Error handling: ${name}`, e);
+    logger.error(`ENTRY Error handling: ${name}`, e);
     const errorResult = requestErrorHandler(e);
     logger.info(`EXIT Error handling: ${name}`);
     return errorResult;

--- a/functions/src/handlers/get-task-handler.ts
+++ b/functions/src/handlers/get-task-handler.ts
@@ -10,7 +10,7 @@ import { HttpStatus } from './http/http-status';
 import { validatePathParams } from './http/validators';
 import { TaskIdPathParamsSchema } from './schemas/task-requests';
 
-const requestHandler: RequestHandlerWithoutContext = async (
+const getTaskHandler: RequestHandlerWithoutContext = async (
   event: APIGatewayEvent,
 ): Promise<LambdaResponse> => {
   const { id: taskId } = validatePathParams(TaskIdPathParamsSchema, event);
@@ -19,4 +19,4 @@ const requestHandler: RequestHandlerWithoutContext = async (
   return httpResponse(HttpStatus.OK, task);
 };
 
-export const handler = handlerFactory('getTask', requestHandler);
+export const handler = handlerFactory('getTask', getTaskHandler);

--- a/functions/src/handlers/update-task-handler.ts
+++ b/functions/src/handlers/update-task-handler.ts
@@ -12,7 +12,7 @@ import {
 import { updateTaskUsecase } from '../usecases/update-task-usecase';
 import { validateBodyAndPathParams } from './http/validators';
 
-const requestHandler: RequestHandlerWithoutContext = async (
+const updateTaskHandler: RequestHandlerWithoutContext = async (
   event: APIGatewayEvent,
 ): Promise<LambdaResponse> => {
   const {
@@ -29,4 +29,4 @@ const requestHandler: RequestHandlerWithoutContext = async (
   return httpResponse(HttpStatus.OK, updatedTask);
 };
 
-export const handler = handlerFactory('updateTask', requestHandler);
+export const handler = handlerFactory('updateTask', updateTaskHandler);

--- a/functions/src/infrastructure/ddb/factory/ddb-factory.ts
+++ b/functions/src/infrastructure/ddb/factory/ddb-factory.ts
@@ -24,7 +24,7 @@ const ddbOperationWithLog = async <T, P extends unknown[]>(
   operation: RepoCommand<T, P>,
   ...args: P
 ): Promise<T> => {
-  logger.info(`START Dynamodb Operation: ${name}`);
+  logger.info(`ENTRY Dynamodb Operation: ${name}`);
   const result = await operation(...args);
   logger.info(`EXIT Dynamodb Operation: ${name}`);
   return result;
@@ -37,7 +37,7 @@ const ddbOperationErrorHandlerWithLog = async <T>(
 ): Promise<T> => {
   logger.error(`An error occurred in Dynamodb Operation: ${name}`);
   if (e instanceof Error) {
-    logger.error(`START Dynamodb Operation error handling: ${name}`);
+    logger.error(`ENTRY Dynamodb Operation error handling: ${name}`);
     const errorResult = processError(e);
     logger.info(`EXIT Dynamodb Operation error handling: ${name}`, errorResult);
     throw errorResult;

--- a/functions/src/infrastructure/ddb/factory/ddb-factory.ts
+++ b/functions/src/infrastructure/ddb/factory/ddb-factory.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../common/logger';
-import { RepoCommand } from '../../../usecases/contracts/task-repository-contract';
+import { RepositoryAction } from '../../../usecases/contracts/task-repository-contract';
 import { DdbError } from '../errors/ddb-errors';
 import { ddbErrorHandler } from './ddb-error-handler';
 
@@ -7,9 +7,9 @@ type DdbOpsErrorHandler = (error: Error) => DdbError;
 
 export const ddbFactory = <T, P extends unknown[]>(
   name: string,
-  ddbOperation: RepoCommand<T, P>,
+  ddbOperation: RepositoryAction<T, P>,
   errorHandler: DdbOpsErrorHandler = ddbErrorHandler,
-): RepoCommand<T, P> => {
+): RepositoryAction<T, P> => {
   return async (...args: P): Promise<T> => {
     try {
       return await ddbOperationWithLog(name, ddbOperation, ...args);
@@ -21,7 +21,7 @@ export const ddbFactory = <T, P extends unknown[]>(
 
 const ddbOperationWithLog = async <T, P extends unknown[]>(
   name: string,
-  operation: RepoCommand<T, P>,
+  operation: RepositoryAction<T, P>,
   ...args: P
 ): Promise<T> => {
   logger.info(`ENTRY Dynamodb Operation: ${name}`);

--- a/functions/src/infrastructure/ddb/task-repository.ts
+++ b/functions/src/infrastructure/ddb/task-repository.ts
@@ -100,17 +100,22 @@ const buildUpdateTaskAttributes = (
 ): DdbUpdateTaskAttributes => {
   const now = new Date().toISOString();
 
-  const fields = Object.entries(data).map(([key, value]) => ({ key, value }));
-  const allFields = [...fields, { key: 'updatedAt', value: now }]; // updatedAtは必ず更新する
+  const attributes = Object.entries(data).map(([key, value]) => ({
+    key,
+    value,
+  }));
+  const attributesWithTime = attributes.concat([
+    { key: 'updatedAt', value: now },
+  ]);
 
-  const expressionParts = allFields.map(
-    (field) => `#${field.key} = :${field.key}`,
+  const expressionParts = attributesWithTime.map(
+    (attr) => `#${attr.key} = :${attr.key}`,
   );
   const expressionAttributeNames = Object.fromEntries(
-    allFields.map((field) => [`#${field.key}`, field.key]),
+    attributesWithTime.map((attr) => [`#${attr.key}`, attr.key]),
   );
   const expressionAttributeValues = Object.fromEntries(
-    allFields.map((field) => [`:${field.key}`, field.value]),
+    attributesWithTime.map((attr) => [`:${attr.key}`, attr.value]),
   );
 
   return {

--- a/functions/src/infrastructure/ddb/task-repository.ts
+++ b/functions/src/infrastructure/ddb/task-repository.ts
@@ -14,13 +14,13 @@ import { ddbFactory } from './factory/ddb-factory';
 import { DdbInternalServerError } from './errors/ddb-errors';
 import { v4 as uuidv4 } from 'uuid';
 import {
-  CreateTaskCommand,
+  CreateTaskAction,
   CreateTaskPayload,
-  DeleteTaskCommand,
-  FindTaskByIdCommand,
+  DeleteTaskAction,
+  FindTaskByIdAction,
   TaskRepository,
   UpdateTaskAtLeastOne,
-  UpdateTaskCommand,
+  UpdateTaskAction,
 } from '../../usecases/contracts/task-repository-contract';
 import { Task } from '../../domain/task';
 import { TaskItemSchema, toTask } from './schemas/task-item';
@@ -36,7 +36,7 @@ const dynamoDBClient = new DynamoDBClient({
 
 const dynamoDb = DynamoDBDocumentClient.from(dynamoDBClient);
 
-const createTaskItem: CreateTaskCommand = async (
+const createTaskItem: CreateTaskAction = async (
   body: CreateTaskPayload,
 ): Promise<string> => {
   const uuid = uuidv4();
@@ -60,7 +60,7 @@ const createTaskItem: CreateTaskCommand = async (
   return uuid;
 };
 
-const findTaskItemById: FindTaskByIdCommand = async (
+const findTaskItemById: FindTaskByIdAction = async (
   taskId: string,
 ): Promise<Task | null> => {
   const commandInput = {
@@ -120,7 +120,7 @@ const buildUpdateTaskAttributes = (
   };
 };
 
-const updateTaskItem: UpdateTaskCommand = async (
+const updateTaskItem: UpdateTaskAction = async (
   taskId: string,
   data: UpdateTaskAtLeastOne,
 ): Promise<Task> => {
@@ -155,7 +155,7 @@ const updateTaskItem: UpdateTaskCommand = async (
   return toTask(parseResult.data);
 };
 
-const deleteTaskItem: DeleteTaskCommand = async (
+const deleteTaskItem: DeleteTaskAction = async (
   taskId: string,
 ): Promise<void> => {
   const commandInput: DeleteCommandInput = {

--- a/functions/src/usecases/contracts/task-repository-contract.ts
+++ b/functions/src/usecases/contracts/task-repository-contract.ts
@@ -1,20 +1,22 @@
 import { Task } from '../../domain/task';
 
-export type RepoCommand<T, P extends unknown[]> = (...args: P) => Promise<T>;
+export type RepositoryAction<T, P extends unknown[]> = (
+  ...args: P
+) => Promise<T>;
 
-export type CreateTaskCommand = RepoCommand<string, [CreateTaskPayload]>;
-export type FindTaskByIdCommand = RepoCommand<Task | null, [string]>;
-export type UpdateTaskCommand = RepoCommand<
+export type CreateTaskAction = RepositoryAction<string, [CreateTaskPayload]>;
+export type FindTaskByIdAction = RepositoryAction<Task | null, [string]>;
+export type UpdateTaskAction = RepositoryAction<
   Task,
   [string, UpdateTaskAtLeastOne]
 >;
-export type DeleteTaskCommand = RepoCommand<void, [string]>;
+export type DeleteTaskAction = RepositoryAction<void, [string]>;
 
 export type TaskRepository = {
-  create: CreateTaskCommand;
-  findById: FindTaskByIdCommand;
-  update: UpdateTaskCommand;
-  delete: DeleteTaskCommand;
+  create: CreateTaskAction;
+  findById: FindTaskByIdAction;
+  update: UpdateTaskAction;
+  delete: DeleteTaskAction;
 };
 
 export type CreateTaskPayload = {

--- a/functions/src/usecases/factory/usecase-factory.ts
+++ b/functions/src/usecases/factory/usecase-factory.ts
@@ -24,7 +24,7 @@ const useCaseWithLog = async <T, P extends unknown[]>(
   useCase: UseCase<T, P>,
   ...args: P
 ): Promise<T> => {
-  logger.info(`START usecase: ${name}`);
+  logger.info(`ENTRY usecase: ${name}`);
   const result = await useCase(...args);
   logger.info(`EXIT usecase: ${name}`);
   return result;
@@ -37,7 +37,7 @@ const useCaseErrorHandlerWithLog = async <T>(
 ): Promise<T> => {
   logger.error(`An error occurred in usecase: ${name}`);
   if (e instanceof Error) {
-    logger.error(`START usecase error handling: ${name}`);
+    logger.error(`ENTRY usecase error handling: ${name}`);
     const errorResult = processError(e);
     logger.info(`EXIT usecase error handling: ${name}`, errorResult);
     throw errorResult;


### PR DESCRIPTION
## 対応内容

### 命名系のリファクタリング

- ハンドラの名前: `requestHandler`から本来の名前へ変更
- ログのSTARTをENTRYへ 
- ユースケースで定義してあるインフラの関数の型の名前を変更 (サフィックスを`Command` -> `Action`へ) 
    - AWS SDKが`Command`を使っているので混乱防止
-  インフラの`UpdateTaskAttributes`を組み立てる部分の変数名