### PR TITLE
API Gatewayへ認証を設定

### DIFF
--- a/cdk/lib/einoji-stack.ts
+++ b/cdk/lib/einoji-stack.ts
@@ -3,7 +3,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as ddb from 'aws-cdk-lib/aws-dynamodb';
 import * as apigw from '@aws-cdk/aws-apigatewayv2-alpha';
 import { HttpLambdaIntegration } from '@aws-cdk/aws-apigatewayv2-integrations-alpha';
-
+import { HttpUserPoolAuthorizer } from '@aws-cdk/aws-apigatewayv2-authorizers-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -44,6 +44,8 @@ export class EinojiStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'UserPoolClientId', {
       value: userPoolClient.userPoolClientId,
     });
+
+    const authorizer = new HttpUserPoolAuthorizer('BooksAuthorizer', userPool);
 
     const tasksTable = new ddb.Table(this, 'TasksTable', {
       tableName: `${SYSTEM_NAME}-${ENV_NAME}-tasks-table`,

--- a/cdk/lib/einoji-stack.ts
+++ b/cdk/lib/einoji-stack.ts
@@ -131,7 +131,9 @@ export class EinojiStack extends cdk.Stack {
     const tasksResource = api.root.addResource('tasks');
     const singleTaskResource = tasksResource.addResource('{id}');
 
-    tasksResource.addMethod('POST', new apigw.LambdaIntegration(createTaskFn));
+    tasksResource.addMethod('POST', new apigw.LambdaIntegration(createTaskFn), {
+      authorizer: authorizer,
+    });
     singleTaskResource.addMethod(
       'GET',
       new apigw.LambdaIntegration(getTaskFn),
@@ -142,10 +144,16 @@ export class EinojiStack extends cdk.Stack {
     singleTaskResource.addMethod(
       'PUT',
       new apigw.LambdaIntegration(updateTaskFn),
+      {
+        authorizer: authorizer,
+      },
     );
     singleTaskResource.addMethod(
       'DELETE',
       new apigw.LambdaIntegration(deleteTaskFn),
+      {
+        authorizer: authorizer,
+      },
     );
 
     const usersResource = api.root.addResource('users');

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -3,12 +3,13 @@
   "version": "0.1.0",
   "scripts": {},
   "devDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.96.2-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.96.2-alpha.0",
-    "aws-cdk": "2.96.2"
+    "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "2.100.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.100.0-alpha.0",
+    "aws-cdk": "^2.100.0",
+    "aws-cdk-lib": "^2.100.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.96.2",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "scripts": {},
   "devDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "2.100.0-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.100.0-alpha.0",
     "aws-cdk": "^2.100.0",
     "aws-cdk-lib": "^2.100.0"
   },

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -86,6 +86,8 @@ paths:
           $ref: '#/components/responses/500Common'
         503:
           $ref: '#/components/responses/503Common'
+      security:
+        - BearerAuth: []
     post:
       tags:
         - tasks
@@ -106,12 +108,16 @@ paths:
                 $ref: '#/components/schemas/Task'
         400:
           $ref: '#/components/responses/400Path'
+        401:
+          $ref: '#/components/responses/401Common'
         422:
           $ref: '#/components/responses/422Common'
         500:
           $ref: '#/components/responses/500Common'
         503:
           $ref: '#/components/responses/503Common'
+      security:
+        - BearerAuth: []
 
   /tasks/{id}:
     get:
@@ -147,13 +153,16 @@ paths:
               examples:
                 INVALID_PATH_PARAMETER:
                   $ref: '#/components/examples/INVALID_PATH_PARAMETER'
+        401:
+          $ref: '#/components/responses/401Common'
         404:
           $ref: '#/components/responses/404Common'
         500:
           $ref: '#/components/responses/500Common'
         503:
           $ref: '#/components/responses/503Common'
-
+      security:
+        - BearerAuth: []
     put:
       tags:
         - tasks
@@ -180,6 +189,8 @@ paths:
                 $ref: '#/components/schemas/Task'
         400:
           $ref: '#/components/responses/400PathAndPayload'
+        401:
+          $ref: '#/components/responses/401Common'
         404:
           $ref: '#/components/responses/404Common'
         422:
@@ -188,6 +199,8 @@ paths:
           $ref: '#/components/responses/500Common'
         503:
           $ref: '#/components/responses/503Common'
+      security:
+        - BearerAuth: []
 
     delete:
       tags:
@@ -205,12 +218,16 @@ paths:
           description: No Content
         400:
           $ref: '#/components/responses/400Path'
+        401:
+          $ref: '#/components/responses/401Common'
         404:
           $ref: '#/components/responses/404Common'
         500:
           $ref: '#/components/responses/500Common'
         503:
           $ref: '#/components/responses/503Common'
+      security:
+        - BearerAuth: []
 
   /tasks/{id}/complete:
     patch:
@@ -239,6 +256,8 @@ paths:
                 $ref: '#/components/schemas/Task'
         400:
           $ref: '#/components/responses/400PathAndPayload'
+        401:
+          $ref: '#/components/responses/401Common'
         404:
           $ref: '#/components/responses/404Common'
         422:
@@ -247,6 +266,8 @@ paths:
           $ref: '#/components/responses/500Common'
         503:
           $ref: '#/components/responses/503Common'
+      security:
+        - BearerAuth: []
 
 components:
   schemas:
@@ -427,6 +448,21 @@ components:
               $ref: '#/components/examples/INVALID_PAYLOAD_FORMAT'
             INVALID_PATH_PARAMETER:
               $ref: '#/components/examples/INVALID_PATH_PARAMETER'
+    401Common:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                enum: [UNAUTHORIZED]
+              message:
+                type: string
+          examples:
+            UNAUTHORIZED:
+              $ref: '#/components/examples/UNAUTHORIZED'
     403UserNotCofirmed:
       description: Forbidden
       content:
@@ -564,7 +600,11 @@ components:
               $ref: '#/components/examples/SERVICE_DOWNTIME'
             EXTERNAL_SERVICE_FAILURE:
               $ref: '#/components/examples/EXTERNAL_SERVICE_FAILURE'
-
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   examples:
     INVALID_PAYLOAD_FORMAT:
       value:
@@ -582,6 +622,10 @@ components:
       value:
         code: REQ004
         message: 'Invalid or missing parameters. Details: ${errorDetails}'
+    UNAUTHORIZED:
+      value:
+        code: REQ005
+        message: 'Unauthorized.'
     INVALID_CREDENTIALS:
       value:
         code: USER001

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -455,14 +455,10 @@ components:
           schema:
             type: object
             properties:
-              code:
-                type: string
-                enum: [UNAUTHORIZED]
               message:
                 type: string
-          examples:
-            UNAUTHORIZED:
-              $ref: '#/components/examples/UNAUTHORIZED'
+                example: Unauthorized
+
     403UserNotCofirmed:
       description: Forbidden
       content:
@@ -622,10 +618,6 @@ components:
       value:
         code: REQ004
         message: 'Invalid or missing parameters. Details: ${errorDetails}'
-    UNAUTHORIZED:
-      value:
-        code: REQ005
-        message: 'Unauthorized.'
     INVALID_CREDENTIALS:
       value:
         code: USER001

--- a/functions/src/infrastructure/cognito/user-repository.ts
+++ b/functions/src/infrastructure/cognito/user-repository.ts
@@ -53,12 +53,12 @@ const auth: AuthUserAction = async (
     },
   });
   const result = await client.send(command);
-  if (!result.AuthenticationResult?.AccessToken) {
+  if (!result.AuthenticationResult?.IdToken) {
     throw new AuthenticationError(
       'Failed to retrieve an access token during user authentication. Please check your credentials and try again.',
     );
   }
-  return result.AuthenticationResult.AccessToken;
+  return result.AuthenticationResult.IdToken;
 };
 
 export const userRepository: UserRepository = {

--- a/functions/tests/small/infrastructure/cognito/user-repository.test.ts
+++ b/functions/tests/small/infrastructure/cognito/user-repository.test.ts
@@ -64,16 +64,16 @@ describe('userRepository.auth', () => {
     cognitoMockClient.reset();
   });
 
-  test('should return AccessToken when authenticating a user with valid email and password', async () => {
+  test('should return IdToken when authenticating a user with valid email and password', async () => {
     const dummyPayload = { email: 'test@example.com', password: 'password123' };
-    const dummyAccessToken = 'dummyAccessTokenValue';
+    const dummyIdToken = 'dummyIdTokenValue';
     cognitoMockClient.on(InitiateAuthCommand).resolves({
-      AuthenticationResult: { AccessToken: dummyAccessToken },
+      AuthenticationResult: { IdToken: dummyIdToken },
     });
 
     const returnedAccessToken = await userRepository.auth(dummyPayload);
 
-    expect(returnedAccessToken).toEqual(dummyAccessToken);
+    expect(returnedAccessToken).toEqual(dummyIdToken);
 
     const callsOfInitiateAuth =
       cognitoMockClient.commandCalls(InitiateAuthCommand);

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,52 +36,8 @@
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "2.100.0-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.100.0-alpha.0",
         "aws-cdk": "^2.100.0",
         "aws-cdk-lib": "^2.100.0"
-      }
-    },
-    "cdk/node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.100.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.100.0-alpha.0.tgz",
-      "integrity": "sha512-JRnwuwGWLV5uZS9bWR4s+Swm7/JmOoRl2GoKGUqPwMiK76JAPwdFAOZfcNBDsHZgLAKXaO39OwjtWv8BSmln5w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.100.0",
-        "constructs": "^10.0.0"
-      }
-    },
-    "cdk/node_modules/@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
-      "version": "2.100.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.100.0-alpha.0.tgz",
-      "integrity": "sha512-BZp70/U2D5ozF1JSfwS0XCoeU23ywUpqIfYvwmLNd/KTvbO/MQU9iYhNIDugtDTarEGUd96nbzDgZGssPBlJig==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
-        "aws-cdk-lib": "^2.100.0",
-        "constructs": "^10.0.0"
-      }
-    },
-    "cdk/node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
-      "version": "2.100.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.100.0-alpha.0.tgz",
-      "integrity": "sha512-tQskKtOLv345HGlqY/NHW4ZoNCVhXwwGV/7xKvguglrJKQLgRsNETE+krn9WCgTXwnWY6UNswr1Bw8mHuuoGwg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
-        "aws-cdk-lib": "^2.100.0",
-        "constructs": "^10.0.0"
       }
     },
     "cdk/node_modules/aws-cdk-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,14 +32,431 @@
       "name": "einoji-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.96.2",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.96.2-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.96.2-alpha.0",
-        "aws-cdk": "2.96.2"
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "2.100.0-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.100.0-alpha.0",
+        "aws-cdk": "^2.100.0",
+        "aws-cdk-lib": "^2.100.0"
+      }
+    },
+    "cdk/node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
+      "version": "2.100.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.100.0-alpha.0.tgz",
+      "integrity": "sha512-JRnwuwGWLV5uZS9bWR4s+Swm7/JmOoRl2GoKGUqPwMiK76JAPwdFAOZfcNBDsHZgLAKXaO39OwjtWv8BSmln5w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.100.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "cdk/node_modules/@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
+      "version": "2.100.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.100.0-alpha.0.tgz",
+      "integrity": "sha512-BZp70/U2D5ozF1JSfwS0XCoeU23ywUpqIfYvwmLNd/KTvbO/MQU9iYhNIDugtDTarEGUd96nbzDgZGssPBlJig==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
+        "aws-cdk-lib": "^2.100.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "cdk/node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
+      "version": "2.100.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.100.0-alpha.0.tgz",
+      "integrity": "sha512-tQskKtOLv345HGlqY/NHW4ZoNCVhXwwGV/7xKvguglrJKQLgRsNETE+krn9WCgTXwnWY6UNswr1Bw8mHuuoGwg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.100.0-alpha.0",
+        "aws-cdk-lib": "^2.100.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib": {
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.100.0.tgz",
+      "integrity": "sha512-oWDPcbdqD69wDIUvcGdbDxmKcDfkCg515wf8JkiQLnhAI/AFyKAVTEWhbSUi00lvJQNUjX8Mal2lbKlCRA4hjQ==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.1.1",
+        "ignore": "^5.2.4",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.0",
+        "semver": "^7.5.4",
+        "table": "^6.8.1",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.5.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "cdk/node_modules/source-map-support": {
@@ -88,42 +505,18 @@
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.200",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.96.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.96.2-alpha.0.tgz",
-      "integrity": "sha512-HNfgzJiViiAjMM9WGz//trDVnwYtojzhjWq2cyNIopM2A/RfU7HNGbVKQl0io+nO7NfUiI14ppFgERQY8JO6+w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "2.96.2",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
-      "version": "2.96.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.96.2-alpha.0.tgz",
-      "integrity": "sha512-5rhxTTkxR8GenCRkNFNMv8UmH3cfOldjKpOZYpML0KK7jxtYz8ElIJMCSOQazi7dSnETtYKaGLpfvuyEpB4Wpw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.96.2-alpha.0",
-        "aws-cdk-lib": "2.96.2",
-        "constructs": "^10.0.0"
-      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -3339,9 +3732,10 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.96.2",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
+      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -3350,345 +3744,6 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/aws-cdk-lib": {
-      "version": "2.96.2",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "table",
-        "yaml"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
-        "yaml": "1.10.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/aws-cdk/node_modules/fsevents": {


### PR DESCRIPTION
## 対応内容

- APIGWへAuthorizerを設定
    - 対象はTaskのCRUD
- APIGWの方式をHTTP APIからREST APIへ
    -  HTTP APIはCDKのコンストラクトがalpha版
    -  Authorizerに至ってはまだL1で書く必要があった
    -  不要になったalpha版はライブラリをアンインストール
- Cognitoのトークンについての間違いを修正
    - 必要なのはアクセストークンではなくIDトークンだった  

### やらないこと

- 関数の中でトークンからユーザー情報を取り出して扱う (次のPRで対応予定)