### PR TITLE
タスクにユーザーIDを紐付け

### DIFF
--- a/functions/src/handlers/tasks/create-task-handler.ts
+++ b/functions/src/handlers/tasks/create-task-handler.ts
@@ -12,9 +12,10 @@ import { HttpStatus } from '../base/http/http-status';
 const createTaskHandler: RequestHandlerWithoutContext = async (
   event,
 ): Promise<LambdaResponse> => {
+  const userId: string = event.requestContext.authorizer?.claims.sub;
   const data: CreateTaskData = validateBody(CreateTaskRequestSchema, event);
 
-  const createdTask = await createTaskUseCase(data);
+  const createdTask = await createTaskUseCase(userId, data);
 
   return httpResponse(HttpStatus.CREATED, createdTask);
 };

--- a/functions/src/handlers/tasks/create-task-handler.ts
+++ b/functions/src/handlers/tasks/create-task-handler.ts
@@ -1,4 +1,3 @@
-import { APIGatewayEvent } from 'aws-lambda';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,
@@ -11,7 +10,7 @@ import { validateBody } from '../base/http/validators';
 import { HttpStatus } from '../base/http/http-status';
 
 const createTaskHandler: RequestHandlerWithoutContext = async (
-  event: APIGatewayEvent,
+  event,
 ): Promise<LambdaResponse> => {
   const data: CreateTaskData = validateBody(CreateTaskRequestSchema, event);
 

--- a/functions/src/handlers/tasks/delete-task-handler.ts
+++ b/functions/src/handlers/tasks/delete-task-handler.ts
@@ -11,8 +11,9 @@ import { validatePathParams } from '../base/http/validators';
 const deleteTaskHandler: RequestHandlerWithoutContext = async (
   event,
 ): Promise<LambdaResponse> => {
+  const userId: string = event.requestContext.authorizer?.claims.sub;
   const { id: taskId } = validatePathParams(TaskIdPathParamsSchema, event);
-  await deleteTaskUseCase(taskId);
+  await deleteTaskUseCase(userId, taskId);
   return httpResponse(HttpStatus.NO_CONTENT);
 };
 

--- a/functions/src/handlers/tasks/delete-task-handler.ts
+++ b/functions/src/handlers/tasks/delete-task-handler.ts
@@ -1,4 +1,3 @@
-import { APIGatewayEvent } from 'aws-lambda';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,
@@ -10,7 +9,7 @@ import { LambdaResponse, httpResponse } from '../base/http/http-response';
 import { validatePathParams } from '../base/http/validators';
 
 const deleteTaskHandler: RequestHandlerWithoutContext = async (
-  event: APIGatewayEvent,
+  event,
 ): Promise<LambdaResponse> => {
   const { id: taskId } = validatePathParams(TaskIdPathParamsSchema, event);
   await deleteTaskUseCase(taskId);

--- a/functions/src/handlers/tasks/get-task-handler.ts
+++ b/functions/src/handlers/tasks/get-task-handler.ts
@@ -11,9 +11,10 @@ import { getTaskUseCase } from '../../usecases/tasks/get-task-usecase';
 const getTaskHandler: RequestHandlerWithoutContext = async (
   event,
 ): Promise<LambdaResponse> => {
+  const userId: string = event.requestContext.authorizer?.claims.sub;
   const { id: taskId } = validatePathParams(TaskIdPathParamsSchema, event);
 
-  const task = await getTaskUseCase(taskId);
+  const task = await getTaskUseCase(userId, taskId);
   return httpResponse(HttpStatus.OK, task);
 };
 

--- a/functions/src/handlers/tasks/get-task-handler.ts
+++ b/functions/src/handlers/tasks/get-task-handler.ts
@@ -1,4 +1,3 @@
-import { APIGatewayEvent } from 'aws-lambda';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,
@@ -10,7 +9,7 @@ import { HttpStatus } from '../base/http/http-status';
 import { getTaskUseCase } from '../../usecases/tasks/get-task-usecase';
 
 const getTaskHandler: RequestHandlerWithoutContext = async (
-  event: APIGatewayEvent,
+  event,
 ): Promise<LambdaResponse> => {
   const { id: taskId } = validatePathParams(TaskIdPathParamsSchema, event);
 

--- a/functions/src/handlers/tasks/update-task-handler.ts
+++ b/functions/src/handlers/tasks/update-task-handler.ts
@@ -24,7 +24,8 @@ const updateTaskHandler: RequestHandlerWithoutContext = async (
     TaskIdPathParamsSchema,
   );
 
-  const updatedTask = await updateTaskUsecase(taskId, updateTaskData);
+  const userId: string = event.requestContext.authorizer?.claims.sub;
+  const updatedTask = await updateTaskUsecase(userId, taskId, updateTaskData);
 
   return httpResponse(HttpStatus.OK, updatedTask);
 };

--- a/functions/src/handlers/tasks/update-task-handler.ts
+++ b/functions/src/handlers/tasks/update-task-handler.ts
@@ -1,4 +1,3 @@
-import { APIGatewayEvent } from 'aws-lambda';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,
@@ -14,7 +13,7 @@ import { validateBodyAndPathParams } from '../base/http/validators';
 import { HttpStatus } from '../base/http/http-status';
 
 const updateTaskHandler: RequestHandlerWithoutContext = async (
-  event: APIGatewayEvent,
+  event,
 ): Promise<LambdaResponse> => {
   const {
     body: updateTaskData,

--- a/functions/src/handlers/users/auth-user-handler.ts
+++ b/functions/src/handlers/users/auth-user-handler.ts
@@ -1,4 +1,4 @@
-import { APIGatewayEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent } from 'aws-lambda';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,
@@ -9,9 +9,7 @@ import { HttpStatus } from '../base/http/http-status';
 import { authUserUsecase } from '../../usecases/users/auth-user-usecase';
 import { AuthUserRequestSchema } from './schemas/user-requests';
 
-const authUserHandler: RequestHandlerWithoutContext = async (
-  event: APIGatewayEvent,
-) => {
+const authUserHandler: RequestHandlerWithoutContext = async (event) => {
   const data = validateBody(AuthUserRequestSchema, event);
   const token = await authUserUsecase(data);
   return httpResponse(HttpStatus.OK, { token: token });

--- a/functions/src/handlers/users/auth-user-handler.ts
+++ b/functions/src/handlers/users/auth-user-handler.ts
@@ -1,4 +1,3 @@
-import { APIGatewayProxyEvent } from 'aws-lambda';
 import {
   RequestHandlerWithoutContext,
   handlerFactory,

--- a/functions/src/handlers/users/create-user-handler.ts
+++ b/functions/src/handlers/users/create-user-handler.ts
@@ -1,4 +1,4 @@
-import { APIGatewayEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent } from 'aws-lambda';
 import { createUserUsecase } from '../../usecases/users/create-user-usecase';
 import {
   RequestHandlerWithoutContext,
@@ -11,7 +11,7 @@ import { CreateUserRequestSchema } from './schemas/user-requests';
 import { CreateUserData } from '../../domain/user/user';
 
 const createUserHandler: RequestHandlerWithoutContext = async (
-  event: APIGatewayEvent,
+  event,
 ): Promise<LambdaResponse> => {
   const data: CreateUserData = validateBody(CreateUserRequestSchema, event);
 

--- a/functions/src/handlers/users/create-user-handler.ts
+++ b/functions/src/handlers/users/create-user-handler.ts
@@ -1,4 +1,3 @@
-import { APIGatewayProxyEvent } from 'aws-lambda';
 import { createUserUsecase } from '../../usecases/users/create-user-usecase';
 import {
   RequestHandlerWithoutContext,

--- a/functions/src/infrastructure/ddb/task-repository.ts
+++ b/functions/src/infrastructure/ddb/task-repository.ts
@@ -37,6 +37,7 @@ const dynamoDBClient = new DynamoDBClient({
 const dynamoDb = DynamoDBDocumentClient.from(dynamoDBClient);
 
 const createTaskItem: CreateTaskAction = async (
+  userId: string,
   body: CreateTaskPayload,
 ): Promise<string> => {
   const uuid = uuidv4();
@@ -45,7 +46,7 @@ const createTaskItem: CreateTaskAction = async (
   const putCommandInput: PutCommandInput = {
     TableName: TABLE_NAME,
     Item: {
-      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246', // fixme 認証を導入するまでは固定値を使う
+      userId: userId,
       taskId: uuid,
       title: body.title,
       description: body.description ? body.description : '',
@@ -61,12 +62,13 @@ const createTaskItem: CreateTaskAction = async (
 };
 
 const findTaskItemById: FindTaskByIdAction = async (
+  userId: string,
   taskId: string,
 ): Promise<Task | null> => {
   const commandInput = {
     TableName: TABLE_NAME,
     Key: {
-      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246', // fixme 認証を導入するまでは固定値を使う
+      userId: userId,
       taskId: taskId,
     },
   };
@@ -126,6 +128,7 @@ const buildUpdateTaskAttributes = (
 };
 
 const updateTaskItem: UpdateTaskAction = async (
+  userId: string,
   taskId: string,
   data: UpdateTaskAtLeastOne,
 ): Promise<Task> => {
@@ -138,7 +141,7 @@ const updateTaskItem: UpdateTaskAction = async (
   const commandInput = {
     TableName: TABLE_NAME,
     Key: {
-      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246', // fixme 認証を導入するまでは固定値を使う
+      userId: userId,
       taskId: taskId,
     },
     UpdateExpression: UpdateExpression,
@@ -161,12 +164,13 @@ const updateTaskItem: UpdateTaskAction = async (
 };
 
 const deleteTaskItem: DeleteTaskAction = async (
+  userId: string,
   taskId: string,
 ): Promise<void> => {
   const commandInput: DeleteCommandInput = {
     TableName: TABLE_NAME,
     Key: {
-      userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246', // fixme 認証を導入するまでは固定値を使う
+      userId: userId,
       taskId: taskId,
     },
   };

--- a/functions/src/usecases/tasks/contracts/task-repository-contracts.ts
+++ b/functions/src/usecases/tasks/contracts/task-repository-contracts.ts
@@ -1,13 +1,19 @@
 import { Task } from '../../../domain/task/task';
 import { RepositoryAction } from '../../base/contract/base-contracts';
 
-export type CreateTaskAction = RepositoryAction<string, [CreateTaskPayload]>;
-export type FindTaskByIdAction = RepositoryAction<Task | null, [string]>;
+export type CreateTaskAction = RepositoryAction<
+  string,
+  [string, CreateTaskPayload]
+>;
+export type FindTaskByIdAction = RepositoryAction<
+  Task | null,
+  [string, string]
+>;
 export type UpdateTaskAction = RepositoryAction<
   Task,
-  [string, UpdateTaskAtLeastOne]
+  [string, string, UpdateTaskAtLeastOne]
 >;
-export type DeleteTaskAction = RepositoryAction<void, [string]>;
+export type DeleteTaskAction = RepositoryAction<void, [string, string]>;
 
 export type TaskRepository = {
   create: CreateTaskAction;

--- a/functions/src/usecases/tasks/create-task-usecase.ts
+++ b/functions/src/usecases/tasks/create-task-usecase.ts
@@ -3,9 +3,12 @@ import { TaskNotFoundError } from '../../domain/task/errors/task-errors';
 import { taskUsecaseFactory } from './factory/task-usecase-factory';
 import { taskRepository } from '../../infrastructure/ddb/task-repository';
 
-const createTask = async (data: CreateTaskData): Promise<Task> => {
-  const newTaskId = await taskRepository.create(data);
-  const createdTask = await taskRepository.findById(newTaskId);
+const createTask = async (
+  userId: string,
+  data: CreateTaskData,
+): Promise<Task> => {
+  const newTaskId = await taskRepository.create(userId, data);
+  const createdTask = await taskRepository.findById(userId, newTaskId);
   if (!createdTask) {
     throw new TaskNotFoundError(
       `Task not found after creation. TaskId: ${newTaskId}}`,

--- a/functions/src/usecases/tasks/delete-task-usecase.ts
+++ b/functions/src/usecases/tasks/delete-task-usecase.ts
@@ -2,13 +2,13 @@ import { TaskNotFoundError } from '../../domain/task/errors/task-errors';
 import { taskRepository } from '../../infrastructure/ddb/task-repository';
 import { taskUsecaseFactory } from './factory/task-usecase-factory';
 
-const deleteTask = async (taskId: string): Promise<void> => {
-  const task = await taskRepository.findById(taskId);
+const deleteTask = async (userId: string, taskId: string): Promise<void> => {
+  const task = await taskRepository.findById(userId, taskId);
   if (!task) {
     throw new TaskNotFoundError(`The task not found. Task ID: ${taskId}`);
   }
 
-  await taskRepository.delete(taskId);
+  await taskRepository.delete(userId, taskId);
 };
 
 export const deleteTaskUseCase = taskUsecaseFactory('deleteTask', deleteTask);

--- a/functions/src/usecases/tasks/get-task-usecase.ts
+++ b/functions/src/usecases/tasks/get-task-usecase.ts
@@ -3,8 +3,8 @@ import { Task } from '../../domain/task/task';
 import { taskRepository } from '../../infrastructure/ddb/task-repository';
 import { taskUsecaseFactory } from './factory/task-usecase-factory';
 
-const getTask = async (taskId: string): Promise<Task> => {
-  const task = await taskRepository.findById(taskId);
+const getTask = async (taskId: string, userId: string): Promise<Task> => {
+  const task = await taskRepository.findById(taskId, userId);
   if (!task) {
     throw new TaskNotFoundError(`The task not found. Task ID: ${taskId}`);
   }

--- a/functions/src/usecases/tasks/update-task-usecase.ts
+++ b/functions/src/usecases/tasks/update-task-usecase.ts
@@ -5,6 +5,7 @@ import { taskUsecaseFactory } from './factory/task-usecase-factory';
 import { UpdateTaskAtLeastOne } from './contracts/task-repository-contracts';
 
 const updateTask = async (
+  userId: string,
   taskId: string,
   data: UpdateTaskData,
 ): Promise<Task> => {
@@ -14,7 +15,11 @@ const updateTask = async (
     );
   }
 
-  return await taskRepository.update(taskId, data as UpdateTaskAtLeastOne);
+  return await taskRepository.update(
+    userId,
+    taskId,
+    data as UpdateTaskAtLeastOne,
+  );
 };
 
 const isEmpty = (obj: object): boolean => {

--- a/functions/tests/medium/infrastructure/ddb/task-repository.test.ts
+++ b/functions/tests/medium/infrastructure/ddb/task-repository.test.ts
@@ -9,6 +9,8 @@ import {
 } from '../../../helpers/task-repository-helpers';
 import { Task } from '../../../../src/domain/task/task';
 
+const dummyUserId = '1a7244c5-06d3-47e2-560e-f0b5534c8246';
+
 const dummyTaskItem: TaskItem = {
   userId: '1a7244c5-06d3-47e2-560e-f0b5534c8246',
   taskId: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
@@ -51,9 +53,9 @@ describe('taskRepository', () => {
         title: dummyTaskItem.title,
         description: dummyTaskItem.description,
       };
-      const newTaskId = await taskRepository.create(dummyTaskBody);
+      const newTaskId = await taskRepository.create(dummyUserId, dummyTaskBody);
 
-      const createdTask = await taskRepository.findById(newTaskId);
+      const createdTask = await taskRepository.findById(dummyUserId, newTaskId);
       expect(createdTask).toBeDefined();
 
       expect(createdTask!.id).toEqual(newTaskId);
@@ -68,14 +70,20 @@ describe('taskRepository', () => {
     afterEach(cleanupTasks);
 
     test('should return the TaskItem by correct task ID', async () => {
-      const Task = await taskRepository.findById(dummyTaskItem.taskId);
+      const Task = await taskRepository.findById(
+        dummyUserId,
+        dummyTaskItem.taskId,
+      );
       expect(Task).toEqual(dummyTask);
     });
 
     test('should return null if the task ID does not exist', async () => {
       const nonExistentTaskId = 'non-existent-task-id';
 
-      const TaskItem = await taskRepository.findById(nonExistentTaskId);
+      const TaskItem = await taskRepository.findById(
+        dummyUserId,
+        nonExistentTaskId,
+      );
       expect(TaskItem).toBeNull();
     });
   });
@@ -90,8 +98,15 @@ describe('taskRepository', () => {
         description: '新しい説明',
       };
 
-      await taskRepository.update(dummyTaskItem.taskId, updateData);
-      const updatedTask = await taskRepository.findById(dummyTaskItem.taskId);
+      await taskRepository.update(
+        dummyUserId,
+        dummyTaskItem.taskId,
+        updateData,
+      );
+      const updatedTask = await taskRepository.findById(
+        dummyUserId,
+        dummyTaskItem.taskId,
+      );
       expect(updatedTask!.title).toEqual(updateData.title);
       expect(updatedTask!.description).toEqual(updateData.description);
     });
@@ -101,8 +116,15 @@ describe('taskRepository', () => {
         title: '新しいタイトルのみ',
       };
 
-      await taskRepository.update(dummyTaskItem.taskId, updateData);
-      const updatedTask = await taskRepository.findById(dummyTaskItem.taskId);
+      await taskRepository.update(
+        dummyUserId,
+        dummyTaskItem.taskId,
+        updateData,
+      );
+      const updatedTask = await taskRepository.findById(
+        dummyUserId,
+        dummyTaskItem.taskId,
+      );
       expect(updatedTask!.title).toEqual(updateData.title);
       expect(updatedTask!.description).toEqual(dummyTaskItem.description);
     });
@@ -113,8 +135,11 @@ describe('taskRepository', () => {
     afterEach(cleanupTasks);
 
     test('should delete the task when provided a correct task ID', async () => {
-      await taskRepository.delete(dummyTaskItem.taskId);
-      const deletedTask = await taskRepository.findById(dummyTaskItem.taskId);
+      await taskRepository.delete(dummyUserId, dummyTaskItem.taskId);
+      const deletedTask = await taskRepository.findById(
+        dummyUserId,
+        dummyTaskItem.taskId,
+      );
       expect(deletedTask).toBeNull();
     });
   });

--- a/functions/tests/small/infrastructure/ddb/task-repository.test.ts
+++ b/functions/tests/small/infrastructure/ddb/task-repository.test.ts
@@ -16,6 +16,8 @@ import { Task } from '../../../../src/domain/task/task';
 const documentMockClient = mockClient(DynamoDBDocumentClient);
 const TASK_TABLE_NAME = process.env.TASKS_TABLE_NAME;
 
+const userId = '1a7244c5-06d3-47e2-560e-f0b5534c8246';
+
 describe('taskRepository.create', () => {
   afterEach(() => {
     documentMockClient.reset();
@@ -26,7 +28,7 @@ describe('taskRepository.create', () => {
     const taskBody = { title: 'Test Task', description: 'Test Description' };
     documentMockClient.on(PutCommand).resolves({});
 
-    const createdTaskId = await taskRepository.create(taskBody);
+    const createdTaskId = await taskRepository.create(userId, taskBody);
 
     const callsOfPut = documentMockClient.commandCalls(PutCommand);
     expect(callsOfPut).toHaveLength(1);
@@ -50,7 +52,7 @@ describe('taskRepository.create', () => {
     const taskBody = { title: 'Test Task' };
     documentMockClient.on(PutCommand).resolves({});
 
-    const createdTaskId = await taskRepository.create(taskBody);
+    const createdTaskId = await taskRepository.create(userId, taskBody);
 
     const callsOfPut = documentMockClient.commandCalls(PutCommand);
     expect(callsOfPut).toHaveLength(1);
@@ -99,7 +101,7 @@ describe('taskRepository.findById', () => {
 
     documentMockClient.on(GetCommand).resolves({ Item: dummyTaskItem });
 
-    const result = await taskRepository.findById(dummyTaskId);
+    const result = await taskRepository.findById(userId, dummyTaskId);
 
     const callsOfGet = documentMockClient.commandCalls(GetCommand);
     expect(callsOfGet).toHaveLength(1);
@@ -115,7 +117,7 @@ describe('taskRepository.findById', () => {
 
   test('should return null if the task is not found', async () => {
     documentMockClient.on(GetCommand).resolves({});
-    const task = await taskRepository.findById('some-task-id');
+    const task = await taskRepository.findById(userId, 'some-task-id');
 
     expect(task).toBeNull();
     expect(documentMockClient.calls()).toHaveLength(1);
@@ -127,7 +129,7 @@ describe('taskRepository.findById', () => {
     };
 
     documentMockClient.on(GetCommand).resolves({ Item: invalidTaskItem });
-    await expect(taskRepository.findById(dummyTaskId)).rejects.toThrow(
+    await expect(taskRepository.findById(userId, dummyTaskId)).rejects.toThrow(
       DdbInternalServerError,
     );
     expect(documentMockClient.calls()).toHaveLength(1);
@@ -228,7 +230,7 @@ describe('taskRepository.update', () => {
         .on(UpdateCommand)
         .resolves({ Attributes: mockedReturnValue });
 
-      const result = await taskRepository.update(taskId, input);
+      const result = await taskRepository.update(userId, taskId, input);
 
       const callsOfUpdate = documentMockClient.commandCalls(UpdateCommand);
       expect(callsOfUpdate).toHaveLength(1);
@@ -262,7 +264,7 @@ describe('taskRepository.delete', () => {
   test('should delete a task for a valid task ID', async () => {
     documentMockClient.on(DeleteCommand).resolves({});
 
-    await taskRepository.delete(dummyTaskId);
+    await taskRepository.delete(userId, dummyTaskId);
 
     const callsOfDelete = documentMockClient.commandCalls(DeleteCommand);
     expect(callsOfDelete).toHaveLength(1);

--- a/functions/tests/small/usecases/tasks/create-task-usecase.test.ts
+++ b/functions/tests/small/usecases/tasks/create-task-usecase.test.ts
@@ -38,6 +38,7 @@ describe('createTaskUseCase', () => {
     updatedAt: '2021-06-22T14:24:02.071Z',
   };
 
+  const userId = 'dummy-user-id';
   const validTaskId = 'valid-task-id';
 
   test.each`
@@ -48,13 +49,13 @@ describe('createTaskUseCase', () => {
     (taskRepository.create as jest.Mock).mockResolvedValue(validTaskId);
     (taskRepository.findById as jest.Mock).mockResolvedValue(task);
 
-    const result = await createTaskUseCase(request);
+    const result = await createTaskUseCase(userId, request);
 
     expect(taskRepository.create).toHaveBeenCalledTimes(1);
-    expect(taskRepository.create).toHaveBeenCalledWith(request);
+    expect(taskRepository.create).toHaveBeenCalledWith(userId, request);
 
     expect(taskRepository.findById).toHaveBeenCalledTimes(1);
-    expect(taskRepository.findById).toHaveBeenCalledWith(validTaskId);
+    expect(taskRepository.findById).toHaveBeenCalledWith(userId, validTaskId);
 
     expect(result).toEqual(task);
   });
@@ -65,14 +66,19 @@ describe('createTaskUseCase', () => {
     (taskRepository.create as jest.Mock).mockResolvedValue(invalidTaskId);
     (taskRepository.findById as jest.Mock).mockResolvedValue(null);
 
-    const err = await createTaskUseCase(dummyCreateTaskRequest).catch((e) => e);
+    const err = await createTaskUseCase(userId, dummyCreateTaskRequest).catch(
+      (e) => e,
+    );
     expect(err).toBeInstanceOf(AppError);
     expect(err.code).toBe(ErrorCode.TASK_NOT_FOUND);
 
     expect(taskRepository.create).toHaveBeenCalledTimes(1);
-    expect(taskRepository.create).toHaveBeenCalledWith(dummyCreateTaskRequest);
+    expect(taskRepository.create).toHaveBeenCalledWith(
+      userId,
+      dummyCreateTaskRequest,
+    );
 
     expect(taskRepository.findById).toHaveBeenCalledTimes(1);
-    expect(taskRepository.findById).toHaveBeenCalledWith(invalidTaskId);
+    expect(taskRepository.findById).toHaveBeenCalledWith(userId, invalidTaskId);
   });
 });

--- a/functions/tests/small/usecases/tasks/delete-task-usecase.test.ts
+++ b/functions/tests/small/usecases/tasks/delete-task-usecase.test.ts
@@ -12,6 +12,7 @@ describe('deleteTaskUseCase', () => {
     (taskRepository.delete as jest.Mock).mockClear();
   });
 
+  const userId = 'dummy-user-id';
   const validTaskId = 'valid-task-id';
 
   test('given a valid taskId, should delete the task', async () => {
@@ -26,25 +27,27 @@ describe('deleteTaskUseCase', () => {
 
     (taskRepository.findById as jest.Mock).mockResolvedValue(dummyTask);
 
-    await deleteTaskUseCase(validTaskId);
+    await deleteTaskUseCase(userId, validTaskId);
 
     expect(taskRepository.findById).toHaveBeenCalledTimes(1);
-    expect(taskRepository.findById).toHaveBeenCalledWith(validTaskId);
+    expect(taskRepository.findById).toHaveBeenCalledWith(userId, validTaskId);
     expect(taskRepository.delete).toHaveBeenCalledTimes(1);
-    expect(taskRepository.delete).toHaveBeenCalledWith(validTaskId);
+    expect(taskRepository.delete).toHaveBeenCalledWith(userId, validTaskId);
   });
 
   test('given a non-existent taskId, should throw AppError with TASK_NOT_FOUND', async () => {
     (taskRepository.findById as jest.Mock).mockResolvedValue(null);
 
-    const err = await deleteTaskUseCase(validTaskId).catch((e: Error) => e);
+    const err = await deleteTaskUseCase(userId, validTaskId).catch(
+      (e: Error) => e,
+    );
 
     if (!(err instanceof AppError)) {
       fail('Error should be an instance of AppError');
     }
     expect(err.code).toBe(ErrorCode.TASK_NOT_FOUND);
     expect(taskRepository.findById).toHaveBeenCalledTimes(1);
-    expect(taskRepository.findById).toHaveBeenCalledWith(validTaskId);
+    expect(taskRepository.findById).toHaveBeenCalledWith(userId, validTaskId);
     expect(taskRepository.delete).not.toHaveBeenCalled();
   });
 });

--- a/functions/tests/small/usecases/tasks/get-task-usecase.test.ts
+++ b/functions/tests/small/usecases/tasks/get-task-usecase.test.ts
@@ -12,6 +12,7 @@ describe('getTask', () => {
   });
 
   test('should return a task when it exists', async () => {
+    const userId = 'dummy-user-id';
     const taskId = 'some-task-id';
     const dummyTask: Task = {
       id: 'f0f8f5a0-309d-11ec-8d3d-0242ac130003',
@@ -23,18 +24,19 @@ describe('getTask', () => {
     };
     (taskRepository.findById as jest.Mock).mockResolvedValueOnce(dummyTask);
 
-    const result = await getTaskUseCase(taskId);
+    const result = await getTaskUseCase(userId, taskId);
 
     expect(result).toEqual(dummyTask);
     expect(taskRepository.findById).toHaveBeenCalledTimes(1);
-    expect(taskRepository.findById).toHaveBeenCalledWith(taskId);
+    expect(taskRepository.findById).toHaveBeenCalledWith(userId, taskId);
   });
 
   test('should throw AppError with TASK_NOT_FOUND when the task is not found', async () => {
+    const userId = 'dummy-user-id';
     const taskId = 'not-found-id';
     (taskRepository.findById as jest.Mock).mockResolvedValueOnce(null);
 
-    const err = await getTaskUseCase(taskId).catch((e: AppError) => e);
+    const err = await getTaskUseCase(userId, taskId).catch((e: AppError) => e);
     if (!(err instanceof AppError)) {
       fail('Error should be an instance of AppError');
     }
@@ -43,6 +45,6 @@ describe('getTask', () => {
     expect(err.code).toBe(ErrorCode.TASK_NOT_FOUND);
 
     expect(taskRepository.findById).toHaveBeenCalledTimes(1);
-    expect(taskRepository.findById).toHaveBeenCalledWith(taskId);
+    expect(taskRepository.findById).toHaveBeenCalledWith(userId, taskId);
   });
 });

--- a/functions/tests/small/usecases/tasks/update-task-usecase.test.ts
+++ b/functions/tests/small/usecases/tasks/update-task-usecase.test.ts
@@ -11,6 +11,7 @@ describe('updateTaskUsecase', () => {
     (taskRepository.update as jest.Mock).mockClear();
   });
 
+  const userId = 'dummy-user-id';
   const validTaskId = 'valid-task-id';
   const situationWithOnlyTitle = 'update data contains only title';
   const situationWithTitleAndDesc =
@@ -39,10 +40,11 @@ describe('updateTaskUsecase', () => {
 
       (taskRepository.update as jest.Mock).mockResolvedValue(dummyUpdatedTask);
 
-      const result = await updateTaskUsecase(validTaskId, updateData);
+      const result = await updateTaskUsecase(userId, validTaskId, updateData);
 
       expect(taskRepository.update).toHaveBeenCalledTimes(1);
       expect(taskRepository.update).toHaveBeenCalledWith(
+        userId,
         validTaskId,
         updateData,
       );
@@ -51,7 +53,9 @@ describe('updateTaskUsecase', () => {
   );
 
   test('given update data is empty, should throw TaskUpdateRuleError', async () => {
-    const err = await updateTaskUsecase(validTaskId, {}).catch((e) => e);
+    const err = await updateTaskUsecase(userId, validTaskId, {}).catch(
+      (e) => e,
+    );
 
     expect(err).toBeInstanceOf(AppError);
     expect(err.code).toEqual(ErrorCode.TASK_UPDATE_RULE_ERROR);


### PR DESCRIPTION
## 対応内容

- Lambda が受け取るイベントの型を`APIGatewayProxyEvent`に変更
- ` userId` として `event.requestContext.authorizer.claims.sub`を使う
  - ハンドラーの factory を見直し
    - ジェネリクスでイベントの型を変えられるようにした
       - デフォルト引数で`APIGatewayProxyEvent`を渡すようにしてある
- `userId`を使うように各層とテストを変更
