### PR TITLE
各層のfactoryの書き方を統一

### DIFF
--- a/functions/src/handlers/base/factory/handler-factory.ts
+++ b/functions/src/handlers/base/factory/handler-factory.ts
@@ -25,16 +25,16 @@ export const handlerFactory =
   async (event, context): Promise<LambdaResponse> => {
     try {
       logger.addContext(context);
-      return await execute(name, requestHandler, event);
+      return await handleRequest(name, requestHandler, event);
     } catch (error: unknown) {
       if (error instanceof AppError) {
-        return handleAppError(name, errorHandler, error);
+        return handleKnownError(name, errorHandler, error);
       }
-      return handleUnexpectedError(name, error);
+      return handlerUnknownError(name, error);
     }
   };
 
-const execute = async <T = APIGatewayProxyEvent>(
+const handleRequest = async <T = APIGatewayProxyEvent>(
   name: string,
   fn: RequestHandlerWithoutContext<T>,
   event: T,
@@ -45,7 +45,7 @@ const execute = async <T = APIGatewayProxyEvent>(
   return result;
 };
 
-const handleAppError = (
+const handleKnownError = (
   name: string,
   errorHandler: RequestErrorHandler,
   error: AppError,
@@ -56,10 +56,7 @@ const handleAppError = (
   return result;
 };
 
-const handleUnexpectedError = (
-  name: string,
-  error: unknown,
-): LambdaResponse => {
+const handlerUnknownError = (name: string, error: unknown): LambdaResponse => {
   logErrorWrapper(name, 'ENTRY', error);
   const result = httpErrorResponse(
     new AppError(ErrorCode.UNKNOWN_ERROR, 'An unexpected error'),

--- a/functions/src/handlers/base/factory/handler-factory.ts
+++ b/functions/src/handlers/base/factory/handler-factory.ts
@@ -34,7 +34,7 @@ export const handlerFactory =
     }
   };
 
-const { log, logError } = createLoggerFunctionsForLayer('handler');
+const { log, logError } = createLoggerFunctionsForLayer('HANDLER');
 
 const handleRequest = async <T = APIGatewayProxyEvent>(
   name: string,

--- a/functions/src/handlers/base/factory/handler-factory.ts
+++ b/functions/src/handlers/base/factory/handler-factory.ts
@@ -16,6 +16,8 @@ export type RequestHandlerWithoutContext<T = APIGatewayProxyEvent> = (
 
 export type RequestErrorHandler = (error: AppError) => LambdaResponse;
 
+const { log, logError } = createLoggerFunctionsForLayer('HANDLER');
+
 export const handlerFactory =
   <T = APIGatewayProxyEvent>(
     name: string,
@@ -33,8 +35,6 @@ export const handlerFactory =
       return handlerUnknownError(name, error);
     }
   };
-
-const { log, logError } = createLoggerFunctionsForLayer('HANDLER');
 
 const handleRequest = async <T = APIGatewayProxyEvent>(
   name: string,

--- a/functions/src/handlers/base/factory/handler-factory.ts
+++ b/functions/src/handlers/base/factory/handler-factory.ts
@@ -16,42 +16,6 @@ export type RequestHandlerWithoutContext<T = APIGatewayProxyEvent> = (
 
 export type RequestErrorHandler = (error: AppError) => LambdaResponse;
 
-const logWrapper = (name: string, action: string) =>
-  logger.info(`${action} handler: ${name}`);
-const logErrorWrapper = (name: string, action: string, error?: unknown) =>
-  logger.error(`${action} error in handler: ${name}`, String(error));
-
-const execute = async <T = APIGatewayProxyEvent>(
-  name: string,
-  fn: RequestHandlerWithoutContext<T>,
-  event: T,
-) => {
-  logWrapper(name, 'ENTRY');
-  const result = await fn(event);
-  logWrapper(name, 'EXIT');
-  return result;
-};
-
-const handleAppError = async (
-  name: string,
-  errorHandler: RequestErrorHandler,
-  error: AppError,
-) => {
-  logErrorWrapper(name, 'ENTRY', error);
-  const result = errorHandler(error);
-  logWrapper(name, 'EXIT');
-  return result;
-};
-
-const handleOtherError = (name: string, error: unknown) => {
-  logErrorWrapper(name, 'ENTRY', error);
-  const result = httpErrorResponse(
-    new AppError(ErrorCode.UNKNOWN_ERROR, 'An unexpected error'),
-  );
-  logErrorWrapper(name, 'EXIT');
-  return result;
-};
-
 export const handlerFactory =
   <T = APIGatewayProxyEvent>(
     name: string,
@@ -64,8 +28,47 @@ export const handlerFactory =
       return await execute(name, requestHandler, event);
     } catch (error: unknown) {
       if (error instanceof AppError) {
-        return await handleAppError(name, errorHandler, error);
+        return handleAppError(name, errorHandler, error);
       }
-      return handleOtherError(name, error);
+      return handleUnexpectedError(name, error);
     }
   };
+
+const execute = async <T = APIGatewayProxyEvent>(
+  name: string,
+  fn: RequestHandlerWithoutContext<T>,
+  event: T,
+): Promise<LambdaResponse> => {
+  logWrapper(name, 'ENTRY');
+  const result = await fn(event);
+  logWrapper(name, 'EXIT');
+  return result;
+};
+
+const handleAppError = (
+  name: string,
+  errorHandler: RequestErrorHandler,
+  error: AppError,
+): LambdaResponse => {
+  logErrorWrapper(name, 'ENTRY', error);
+  const result = errorHandler(error);
+  logWrapper(name, 'EXIT');
+  return result;
+};
+
+const handleUnexpectedError = (
+  name: string,
+  error: unknown,
+): LambdaResponse => {
+  logErrorWrapper(name, 'ENTRY', error);
+  const result = httpErrorResponse(
+    new AppError(ErrorCode.UNKNOWN_ERROR, 'An unexpected error'),
+  );
+  logErrorWrapper(name, 'EXIT');
+  return result;
+};
+
+const logWrapper = (name: string, action: string) =>
+  logger.info(`${action} handler: ${name}`);
+const logErrorWrapper = (name: string, action: string, error?: unknown) =>
+  logger.error(`${action} error in handler: ${name}`, String(error));

--- a/functions/src/infrastructure/base/factory/infra-factory.ts
+++ b/functions/src/infrastructure/base/factory/infra-factory.ts
@@ -1,8 +1,10 @@
 import { InfraAction } from '../../../usecases/base/contract/base-contracts';
-import { logger } from '../../../utils/logger';
+import { createLoggerFunctionsForLayer, logger } from '../../../utils/logger';
 import { InfraError } from '../errors/infra-errors';
 
 type InfraErrorHandler = (error: Error) => InfraError;
+
+const { log, logError } = createLoggerFunctionsForLayer('infra');
 
 export const infraFactory = <T, P extends unknown[]>(
   name: string,
@@ -27,9 +29,9 @@ const executeAction = async <T, P extends unknown[]>(
   operation: InfraAction<T, P>,
   ...args: P
 ): Promise<T> => {
-  logWrapper(name, 'ENTRY');
+  log('ENTRY', name);
   const result = await operation(...args);
-  logWrapper(name, 'EXIT');
+  log('EXIT', name);
   return result;
 };
 
@@ -38,20 +40,15 @@ const handleKnownError = (
   processError: InfraErrorHandler,
   error: Error,
 ): InfraError => {
-  logErrorWrapper(name, 'ENTRY', error);
+  logError('ENTRY', name, error);
   const result = processError(error);
-  logWrapper(name, 'EXIT');
+  log('EXIT', name);
   return result;
 };
 
 const handleUnknownError = (name: string, error: unknown): Error => {
-  logErrorWrapper(name, 'ENTRY', error);
+  logError('ENTRY', name, error);
   const result = new Error('An unexpected error');
-  logErrorWrapper(name, 'EXIT');
+  logError('EXIT', name);
   return result;
 };
-
-const logWrapper = (name: string, action: string) =>
-  logger.info(`${action} infra: ${name}`);
-const logErrorWrapper = (name: string, action: string, error?: unknown) =>
-  logger.error(`${action} error in infra: ${name}`, String(error));

--- a/functions/src/infrastructure/base/factory/infra-factory.ts
+++ b/functions/src/infrastructure/base/factory/infra-factory.ts
@@ -4,7 +4,7 @@ import { InfraError } from '../errors/infra-errors';
 
 type InfraErrorHandler = (error: Error) => InfraError;
 
-const { log, logError } = createLoggerFunctionsForLayer('infra');
+const { log, logError } = createLoggerFunctionsForLayer('INFRA');
 
 export const infraFactory = <T, P extends unknown[]>(
   name: string,

--- a/functions/src/infrastructure/cognito/factory/cognito-factory.ts
+++ b/functions/src/infrastructure/cognito/factory/cognito-factory.ts
@@ -1,4 +1,4 @@
-import { RepositoryAction } from '../../../usecases/base/contract/base-contracts';
+import { InfraAction } from '../../../usecases/base/contract/base-contracts';
 import { infraFactory } from '../../base/factory/infra-factory';
 import { CognitoError } from '../errors/cognito-errors';
 import { cognitoErrorHandler } from './cognito-error-handler';
@@ -7,8 +7,8 @@ type CognitoOpsErrorHandler = (error: Error) => CognitoError;
 
 export const cognitoFactory = <T, P extends unknown[]>(
   name: string,
-  operation: RepositoryAction<T, P>,
+  operation: InfraAction<T, P>,
   errorHandler: CognitoOpsErrorHandler = cognitoErrorHandler,
-): RepositoryAction<T, P> => {
+): InfraAction<T, P> => {
   return infraFactory(name, operation, errorHandler);
 };

--- a/functions/src/infrastructure/ddb/factory/ddb-factory.ts
+++ b/functions/src/infrastructure/ddb/factory/ddb-factory.ts
@@ -1,4 +1,4 @@
-import { RepositoryAction } from '../../../usecases/base/contract/base-contracts';
+import { InfraAction } from '../../../usecases/base/contract/base-contracts';
 import { infraFactory } from '../../base/factory/infra-factory';
 import { DdbError } from '../errors/ddb-errors';
 
@@ -8,8 +8,8 @@ type DdbOpsErrorHandler = (error: Error) => DdbError;
 
 export const ddbFactory = <T, P extends unknown[]>(
   name: string,
-  operation: RepositoryAction<T, P>,
+  operation: InfraAction<T, P>,
   errorHandler: DdbOpsErrorHandler = ddbErrorHandler,
-): RepositoryAction<T, P> => {
+): InfraAction<T, P> => {
   return infraFactory(name, operation, errorHandler);
 };

--- a/functions/src/usecases/base/contract/base-contracts.ts
+++ b/functions/src/usecases/base/contract/base-contracts.ts
@@ -1,3 +1,1 @@
-export type RepositoryAction<T, P extends unknown[]> = (
-  ...args: P
-) => Promise<T>;
+export type InfraAction<T, P extends unknown[]> = (...args: P) => Promise<T>;

--- a/functions/src/usecases/base/factory/usecase-factory.ts
+++ b/functions/src/usecases/base/factory/usecase-factory.ts
@@ -5,7 +5,7 @@ import { ErrorCode } from '../../../utils/errors/error-codes';
 export type UseCase<T, P extends unknown[]> = (...args: P) => Promise<T>;
 export type UseCaseErrorHandler = (error: Error) => AppError;
 
-const { log, logError } = createLoggerFunctionsForLayer('usecase');
+const { log, logError } = createLoggerFunctionsForLayer('USECASE');
 
 export const useCaseFactory = <T, P extends unknown[]>(
   name: string,

--- a/functions/src/usecases/tasks/contracts/task-repository-contracts.ts
+++ b/functions/src/usecases/tasks/contracts/task-repository-contracts.ts
@@ -1,19 +1,13 @@
 import { Task } from '../../../domain/task/task';
-import { RepositoryAction } from '../../base/contract/base-contracts';
+import { InfraAction } from '../../base/contract/base-contracts';
 
-export type CreateTaskAction = RepositoryAction<
-  string,
-  [string, CreateTaskPayload]
->;
-export type FindTaskByIdAction = RepositoryAction<
-  Task | null,
-  [string, string]
->;
-export type UpdateTaskAction = RepositoryAction<
+export type CreateTaskAction = InfraAction<string, [string, CreateTaskPayload]>;
+export type FindTaskByIdAction = InfraAction<Task | null, [string, string]>;
+export type UpdateTaskAction = InfraAction<
   Task,
   [string, string, UpdateTaskAtLeastOne]
 >;
-export type DeleteTaskAction = RepositoryAction<void, [string, string]>;
+export type DeleteTaskAction = InfraAction<void, [string, string]>;
 
 export type TaskRepository = {
   create: CreateTaskAction;

--- a/functions/src/usecases/tasks/factory/task-usecase-factory.ts
+++ b/functions/src/usecases/tasks/factory/task-usecase-factory.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../../../utils/errors/app-errors';
-import { usecaseFactory } from '../../base/factory/usecase-factory';
+import { useCaseFactory } from '../../base/factory/usecase-factory';
 import { taskUsecaseErrorHandler } from './task-usecase-error-handler';
 
 type UseCase<T, P extends unknown[]> = (...args: P) => Promise<T>;
@@ -10,5 +10,5 @@ export const taskUsecaseFactory = <T, P extends unknown[]>(
   useCase: UseCase<T, P>,
   errorHandler: UseCaseErrorHandler = taskUsecaseErrorHandler,
 ): UseCase<T, P> => {
-  return usecaseFactory(name, useCase, errorHandler);
+  return useCaseFactory(name, useCase, errorHandler);
 };

--- a/functions/src/usecases/users/contracts/user-repository-contract.ts
+++ b/functions/src/usecases/users/contracts/user-repository-contract.ts
@@ -1,9 +1,9 @@
 import { Email } from '../../../domain/user/email';
 import { Password } from '../../../domain/user/password';
-import { RepositoryAction } from '../../base/contract/base-contracts';
+import { InfraAction } from '../../base/contract/base-contracts';
 
-export type CreateUserAction = RepositoryAction<string, [CreateUserPayload]>;
-export type AuthUserAction = RepositoryAction<string, [AuthUserPayload]>;
+export type CreateUserAction = InfraAction<string, [CreateUserPayload]>;
+export type AuthUserAction = InfraAction<string, [AuthUserPayload]>;
 
 export type UserRepository = {
   create: CreateUserAction;

--- a/functions/src/usecases/users/factory/user-usecase-factory.ts
+++ b/functions/src/usecases/users/factory/user-usecase-factory.ts
@@ -1,7 +1,7 @@
 import {
   UseCase,
   UseCaseErrorHandler,
-  usecaseFactory,
+  useCaseFactory,
 } from '../../base/factory/usecase-factory';
 import { userUsecaseErrorHandler } from './user-usecase-error-handler';
 
@@ -10,5 +10,5 @@ export const userUseCaseFactory = <T, P extends unknown[]>(
   useCase: UseCase<T, P>,
   errorHandler: UseCaseErrorHandler = userUsecaseErrorHandler,
 ): UseCase<T, P> => {
-  return usecaseFactory(name, useCase, errorHandler);
+  return useCaseFactory(name, useCase, errorHandler);
 };

--- a/functions/src/utils/logger.ts
+++ b/functions/src/utils/logger.ts
@@ -1,11 +1,11 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 export const logger = new Logger();
 
-type LoggingLayer = 'handler' | 'usecase' | 'infra';
+type LoggingLayer = 'HANDLER' | 'USECASE' | 'INFRA';
 type LoggingAction = 'ENTRY' | 'EXIT';
 
 const log = (layer: LoggingLayer, action: LoggingAction, name: string) =>
-  logger.info(`${action} ${layer}: ${name}`);
+  logger.info(`${action}: ${layer} ${name}`);
 
 const createLayerSpecificLogger = (layer: LoggingLayer) => {
   return (action: LoggingAction, name: string) => {

--- a/functions/src/utils/logger.ts
+++ b/functions/src/utils/logger.ts
@@ -1,2 +1,41 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 export const logger = new Logger();
+
+type LoggingLayer = 'handler' | 'usecase' | 'infra';
+type LoggingAction = 'ENTRY' | 'EXIT';
+
+const log = (layer: LoggingLayer, action: LoggingAction, name: string) =>
+  logger.info(`${action} ${layer}: ${name}`);
+
+const createLayerSpecificLogger = (layer: LoggingLayer) => {
+  return (action: LoggingAction, name: string) => {
+    log(layer, action, name);
+  };
+};
+
+const logError = (
+  layer: LoggingLayer,
+  action: LoggingAction,
+  name: string,
+  error?: unknown,
+) => logger.error(`${action} error in ${layer}: ${name}`, String(error));
+
+const createLayerSpecificErrorLogger = (layer: LoggingLayer) => {
+  return (action: LoggingAction, name: string, error?: unknown) => {
+    logError(layer, action, name, error);
+  };
+};
+
+type LoggerFunctions = {
+  log: (action: LoggingAction, name: string) => void;
+  logError: (action: LoggingAction, name: string, error?: unknown) => void;
+};
+
+export const createLoggerFunctionsForLayer = (
+  layer: LoggingLayer,
+): LoggerFunctions => {
+  return {
+    log: createLayerSpecificLogger(layer),
+    logError: createLayerSpecificErrorLogger(layer),
+  };
+};


### PR DESCRIPTION
## Issue

- https://github.com/ky0yk/einoji/issues/56

close #56

## 対応内容

- factoryの書き方を統一
    -  おおまかに以下の書き方で命名も可能な限り揃えた
        - メイン処理 
        - 想定内例外
        - 想定外例外
- factory向けのログ関数(ENTRY, EXITを制御しているもの)を集約
    -  部分適用を使って層の名前は1度渡せばいい形にした 