### PR TITLE
エラー系のリファクタリング

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -569,14 +569,10 @@ components:
             properties:
               code:
                 type: string
-                enum: [DATABASE_CONNECTION_ERROR, TIMEOUT, UNKNOWN_ERROR]
+                enum: [UNKNOWN_ERROR]
               message:
                 type: string
           examples:
-            DATABASE_CONNECTION_ERROR:
-              $ref: '#/components/examples/DATABASE_CONNECTION_ERROR'
-            TIMEOUT:
-              $ref: '#/components/examples/TIMEOUT'
             UNKNOWN_ERROR:
               $ref: '#/components/examples/UNKNOWN_ERROR'
     503Common:
@@ -588,12 +584,10 @@ components:
             properties:
               code:
                 type: 'string'
-                enum: [SERVICE_DOWNTIME, EXTERNAL_SERVICE_FAILURE]
+                enum: [EXTERNAL_SERVICE_FAILURE]
               message:
                 type: 'string'
           examples:
-            SERVICE_DOWNTIME:
-              $ref: '#/components/examples/SERVICE_DOWNTIME'
             EXTERNAL_SERVICE_FAILURE:
               $ref: '#/components/examples/EXTERNAL_SERVICE_FAILURE'
   securitySchemes:
@@ -650,22 +644,10 @@ components:
       value:
         code: APP002
         message: 'Provided data does not follow update rules.'
-    DATABASE_CONNECTION_ERROR:
-      value:
-        code: SYS001
-        message: 'Database connection error.'
-    SERVICE_DOWNTIME:
-      value:
-        code: SYS002
-        message: 'Service is currently unavailable.'
     EXTERNAL_SERVICE_FAILURE:
       value:
-        code: SYS003
+        code: SYS001
         message: 'External service error.'
-    TIMEOUT:
-      value:
-        code: SYS004
-        message: 'Processing timeout.'
     UNKNOWN_ERROR:
       value:
         code: SYS999

--- a/functions/src/infrastructure/ddb/errors/ddb-errors.ts
+++ b/functions/src/infrastructure/ddb/errors/ddb-errors.ts
@@ -2,7 +2,5 @@ import { baseInfraError } from '../../base/errors/base-infra-errors';
 
 export class DdbError extends baseInfraError {}
 
-export class DdbResourceNotFoundError extends DdbError {}
-export class DdbProvisionedThroughputExceededError extends DdbError {}
 export class DdbValidationError extends DdbError {}
 export class DdbInternalServerError extends DdbError {}

--- a/functions/src/infrastructure/ddb/factory/ddb-error-handler.ts
+++ b/functions/src/infrastructure/ddb/factory/ddb-error-handler.ts
@@ -1,19 +1,16 @@
 import {
   DdbError,
   DdbInternalServerError,
-  DdbProvisionedThroughputExceededError,
-  DdbResourceNotFoundError,
   DdbValidationError,
 } from '../errors/ddb-errors';
 
 export const ddbErrorHandler = (error: Error): DdbError => {
   switch (error.name) {
-    case 'ResourceNotFoundException':
-      return new DdbResourceNotFoundError(error.message, error);
-    case 'ProvisionedThroughputExceededException':
-      return new DdbProvisionedThroughputExceededError(error.message, error);
     case 'ValidationException':
       return new DdbValidationError(error.message, error);
+    case 'ResourceNotFoundException':
+    case 'ProvisionedThroughputExceededException':
+      return new DdbInternalServerError(error.message, error);
     default:
       return new DdbInternalServerError(error.message, error);
   }

--- a/functions/src/usecases/tasks/factory/task-usecase-error-handler.ts
+++ b/functions/src/usecases/tasks/factory/task-usecase-error-handler.ts
@@ -22,7 +22,7 @@ export const taskUsecaseErrorHandler = (
     error instanceof DdbInternalServerError
   ) {
     return new AppError(
-      ErrorCode.DATABASE_CONNECTION_ERROR,
+      ErrorCode.EXTERNAL_SERVICE_FAILURE,
       error.message,
       error,
     );

--- a/functions/src/usecases/tasks/factory/task-usecase-error-handler.ts
+++ b/functions/src/usecases/tasks/factory/task-usecase-error-handler.ts
@@ -8,27 +8,21 @@ import {
 import {
   DdbError,
   DdbInternalServerError,
-  DdbProvisionedThroughputExceededError,
-  DdbResourceNotFoundError,
   DdbValidationError,
 } from '../../../infrastructure/ddb/errors/ddb-errors';
 
 export const taskUsecaseErrorHandler = (
   error: DdbError | TaskError,
 ): AppError => {
-  if (
-    error instanceof DdbResourceNotFoundError ||
-    error instanceof DdbProvisionedThroughputExceededError ||
-    error instanceof DdbInternalServerError
-  ) {
+  if (error instanceof DdbValidationError) {
+    return new AppError(ErrorCode.INVALID_PAYLOAD_VALUE, error.message, error);
+  }
+  if (error instanceof DdbInternalServerError) {
     return new AppError(
       ErrorCode.EXTERNAL_SERVICE_FAILURE,
       error.message,
       error,
     );
-  }
-  if (error instanceof DdbValidationError) {
-    return new AppError(ErrorCode.INVALID_PAYLOAD_VALUE, error.message, error);
   }
   if (error instanceof TaskNotFoundError) {
     return new AppError(ErrorCode.TASK_NOT_FOUND, error.message, error);

--- a/functions/src/utils/errors/error-codes.ts
+++ b/functions/src/utils/errors/error-codes.ts
@@ -7,26 +7,24 @@ export enum ErrorCode {
   INVALID_QUERY_PARAMETER = 'REQ003', // クエリパラメータが不足または不正
   INVALID_PATH_PARAMETER = 'REQ004', // パスパラメータが不足または不正
 
-  // アプリケーション例外（回復可）
-  TASK_NOT_FOUND = 'APP001', // 存在しないTODOのIDでの操作
-  TASK_UPDATE_RULE_ERROR = 'APP002', // TODOの更新ルール違反
+  // タスクに関する例外（回復可）
+  TASK_NOT_FOUND = 'APP001', // 存在しないTASKのIDでの操作
+  TASK_UPDATE_RULE_ERROR = 'APP002', // TASKの更新ルール違反
 
-  // アプリケーション例外（回復不可） 必要になったらAPP101から始める
+  // タスクに関する例外（回復不可） 必要になったらAPP101から始める
 
   // ユーザーに関する例外（回復可）
   INVALID_CREDENTIALS = 'USER001', // ユーザー認証情報が不正
   USER_NOT_FOUND = 'USER002', // ユーザーが存在しない
   INVALID_PASSWORD_FORMAT = 'USER003', // パスワードの形式が不正
   INVALID_EMAIL_FORMAT = 'USER004', // Eメールの形式が不正
+  USER_EMAIL_EXISTS = 'USER005', // メールアドレスが既に存在する
+  USER_NOT_CONFIRMED = 'USER006', // ユーザーが未確認
 
-  // ユーザーに関する例外（回復不可）
-  USER_EMAIL_EXISTS = 'USER101', // メールアドレスが既に存在する
-  USER_NOT_CONFIRMED = 'USER102', // ユーザーが未確認
+  // ユーザーに関する例外（回復不可） 必要になったらUSER101から始める
 
   // システム例外
-  DATABASE_CONNECTION_ERROR = 'SYS001', // データベース接続エラー（DynamoDBへの接続障害）
-  SERVICE_DOWNTIME = 'SYS002', // APIサービスダウンタイム (API GatewayやLambdaのダウンタイム)
-  EXTERNAL_SERVICE_FAILURE = 'SYS003', // 外部サービスの障害
+  EXTERNAL_SERVICE_FAILURE = 'SYS001', // 外部サービスの障害
   UNKNOWN_ERROR = 'SYS999', // 予期しないエラー
 }
 
@@ -56,11 +54,9 @@ export const errorCodetoStatus = (errorCode: ErrorCode): HttpStatus => {
     case ErrorCode.INVALID_EMAIL_FORMAT:
       return HttpStatus.UNPROCESSABLE_ENTITY;
 
-    case ErrorCode.DATABASE_CONNECTION_ERROR:
     case ErrorCode.UNKNOWN_ERROR:
       return HttpStatus.INTERNAL_SERVER_ERROR;
 
-    case ErrorCode.SERVICE_DOWNTIME:
     case ErrorCode.EXTERNAL_SERVICE_FAILURE:
       return HttpStatus.SERVICE_UNAVAILABLE;
 

--- a/functions/src/utils/errors/error-codes.ts
+++ b/functions/src/utils/errors/error-codes.ts
@@ -7,11 +7,11 @@ export enum ErrorCode {
   INVALID_QUERY_PARAMETER = 'REQ003', // クエリパラメータが不足または不正
   INVALID_PATH_PARAMETER = 'REQ004', // パスパラメータが不足または不正
 
-  // タスクに関する例外（回復可）
+  // アプリケーション例外（回復可）
   TASK_NOT_FOUND = 'APP001', // 存在しないTASKのIDでの操作
   TASK_UPDATE_RULE_ERROR = 'APP002', // TASKの更新ルール違反
 
-  // タスクに関する例外（回復不可） 必要になったらAPP101から始める
+  // アプリケーション例外（回復不可） 必要になったらAPP101から始める
 
   // ユーザーに関する例外（回復可）
   INVALID_CREDENTIALS = 'USER001', // ユーザー認証情報が不正

--- a/functions/tests/small/handlers/base/factory/http-error-handler.test.ts
+++ b/functions/tests/small/handlers/base/factory/http-error-handler.test.ts
@@ -4,24 +4,22 @@ import { ErrorCode } from '../../../../../src/utils/errors/error-codes';
 
 describe('httpErrorHandler', () => {
   test.each`
-    errorCode                              | expected_http_status_code
+    errorCode                             | expected_http_status_code
     // 400
-    ${ErrorCode.INVALID_PAYLOAD_FORMAT}    | ${400}
-    ${ErrorCode.INVALID_QUERY_PARAMETER}   | ${400}
-    ${ErrorCode.INVALID_PATH_PARAMETER}    | ${400}
-    ${ErrorCode.INVALID_CREDENTIALS}       | ${401}
-    ${ErrorCode.USER_NOT_CONFIRMED}        | ${403}
-    ${ErrorCode.TASK_NOT_FOUND}            | ${404}
-    ${ErrorCode.USER_NOT_FOUND}            | ${404}
-    ${ErrorCode.USER_EMAIL_EXISTS}         | ${409}
-    ${ErrorCode.INVALID_PAYLOAD_VALUE}     | ${422}
-    ${ErrorCode.TASK_UPDATE_RULE_ERROR}    | ${422}
-    ${ErrorCode.INVALID_PASSWORD_FORMAT}   | ${422}
-    ${ErrorCode.INVALID_EMAIL_FORMAT}      | ${422}
-    ${ErrorCode.DATABASE_CONNECTION_ERROR} | ${500}
-    ${ErrorCode.UNKNOWN_ERROR}             | ${500}
-    ${ErrorCode.SERVICE_DOWNTIME}          | ${503}
-    ${ErrorCode.EXTERNAL_SERVICE_FAILURE}  | ${503}
+    ${ErrorCode.INVALID_PAYLOAD_FORMAT}   | ${400}
+    ${ErrorCode.INVALID_QUERY_PARAMETER}  | ${400}
+    ${ErrorCode.INVALID_PATH_PARAMETER}   | ${400}
+    ${ErrorCode.INVALID_CREDENTIALS}      | ${401}
+    ${ErrorCode.USER_NOT_CONFIRMED}       | ${403}
+    ${ErrorCode.TASK_NOT_FOUND}           | ${404}
+    ${ErrorCode.USER_NOT_FOUND}           | ${404}
+    ${ErrorCode.USER_EMAIL_EXISTS}        | ${409}
+    ${ErrorCode.INVALID_PAYLOAD_VALUE}    | ${422}
+    ${ErrorCode.TASK_UPDATE_RULE_ERROR}   | ${422}
+    ${ErrorCode.INVALID_PASSWORD_FORMAT}  | ${422}
+    ${ErrorCode.INVALID_EMAIL_FORMAT}     | ${422}
+    ${ErrorCode.UNKNOWN_ERROR}            | ${500}
+    ${ErrorCode.EXTERNAL_SERVICE_FAILURE} | ${503}
   `(
     'given an AppError with code $errorCode it should return a response with status $expected_http_status_code',
     ({ errorCode, expected_http_status_code }) => {

--- a/functions/tests/small/infrastructure/ddb/factory/ddb-error-handler.test.ts
+++ b/functions/tests/small/infrastructure/ddb/factory/ddb-error-handler.test.ts
@@ -1,7 +1,5 @@
 import {
   DdbInternalServerError,
-  DdbProvisionedThroughputExceededError,
-  DdbResourceNotFoundError,
   DdbValidationError,
 } from '../../../../../src/infrastructure/ddb/errors/ddb-errors';
 import { ddbErrorHandler } from '../../../../../src/infrastructure/ddb/factory/ddb-error-handler';
@@ -9,8 +7,8 @@ import { ddbErrorHandler } from '../../../../../src/infrastructure/ddb/factory/d
 describe('ddbErrorHandler', () => {
   test.each`
     original_error_name                         | expected_error_class
-    ${'ResourceNotFoundException'}              | ${DdbResourceNotFoundError}
-    ${'ProvisionedThroughputExceededException'} | ${DdbProvisionedThroughputExceededError}
+    ${'ResourceNotFoundException'}              | ${DdbInternalServerError}
+    ${'ProvisionedThroughputExceededException'} | ${DdbInternalServerError}
     ${'ValidationException'}                    | ${DdbValidationError}
     ${'SomeUnknownException'}                   | ${DdbInternalServerError}
   `(

--- a/functions/tests/small/usecases/tasks/factory/task-usecase-error-handler.test.ts
+++ b/functions/tests/small/usecases/tasks/factory/task-usecase-error-handler.test.ts
@@ -19,10 +19,10 @@ describe('useCaseErrorHandler', () => {
     error_instance                                                  | expected_error_code
     ${new TaskNotFoundError('')}                                    | ${ErrorCode.TASK_NOT_FOUND}
     ${new TaskUpdateRuleError('')}                                  | ${ErrorCode.TASK_UPDATE_RULE_ERROR}
-    ${new DdbResourceNotFoundError('', originalError)}              | ${ErrorCode.DATABASE_CONNECTION_ERROR}
-    ${new DdbProvisionedThroughputExceededError('', originalError)} | ${ErrorCode.DATABASE_CONNECTION_ERROR}
+    ${new DdbResourceNotFoundError('', originalError)}              | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
+    ${new DdbProvisionedThroughputExceededError('', originalError)} | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
     ${new DdbValidationError('', originalError)}                    | ${ErrorCode.INVALID_PAYLOAD_VALUE}
-    ${new DdbInternalServerError('', originalError)}                | ${ErrorCode.DATABASE_CONNECTION_ERROR}
+    ${new DdbInternalServerError('', originalError)}                | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
     ${new Error('Some other error')}                                | ${ErrorCode.UNKNOWN_ERROR}
   `(
     'given $error_instance it should return an error with class $EXPECTED_ERROR_CLASS and code $expected_error_code',

--- a/functions/tests/small/usecases/tasks/factory/task-usecase-error-handler.test.ts
+++ b/functions/tests/small/usecases/tasks/factory/task-usecase-error-handler.test.ts
@@ -3,8 +3,6 @@ import {
   TaskUpdateRuleError,
 } from '../../../../../src/domain/task/errors/task-errors';
 import {
-  DdbResourceNotFoundError,
-  DdbProvisionedThroughputExceededError,
   DdbValidationError,
   DdbInternalServerError,
 } from '../../../../../src/infrastructure/ddb/errors/ddb-errors';
@@ -16,14 +14,12 @@ describe('useCaseErrorHandler', () => {
   const originalError = new Error('Original DDB error');
 
   test.each`
-    error_instance                                                  | expected_error_code
-    ${new TaskNotFoundError('')}                                    | ${ErrorCode.TASK_NOT_FOUND}
-    ${new TaskUpdateRuleError('')}                                  | ${ErrorCode.TASK_UPDATE_RULE_ERROR}
-    ${new DdbResourceNotFoundError('', originalError)}              | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
-    ${new DdbProvisionedThroughputExceededError('', originalError)} | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
-    ${new DdbValidationError('', originalError)}                    | ${ErrorCode.INVALID_PAYLOAD_VALUE}
-    ${new DdbInternalServerError('', originalError)}                | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
-    ${new Error('Some other error')}                                | ${ErrorCode.UNKNOWN_ERROR}
+    error_instance                                   | expected_error_code
+    ${new TaskNotFoundError('')}                     | ${ErrorCode.TASK_NOT_FOUND}
+    ${new TaskUpdateRuleError('')}                   | ${ErrorCode.TASK_UPDATE_RULE_ERROR}
+    ${new DdbValidationError('', originalError)}     | ${ErrorCode.INVALID_PAYLOAD_VALUE}
+    ${new DdbInternalServerError('', originalError)} | ${ErrorCode.EXTERNAL_SERVICE_FAILURE}
+    ${new Error('Some other error')}                 | ${ErrorCode.UNKNOWN_ERROR}
   `(
     'given $error_instance it should return an error with class $EXPECTED_ERROR_CLASS and code $expected_error_code',
     ({ error_instance, expected_error_code }) => {


### PR DESCRIPTION
## Issue

- #38 
- #39 

close #38, #39 

## 対応内容

- プログラムから明示的に返さなくていいエラーコードを削除
    - API Gatewayに任せる
    - `Unauthorized`は認証まわりでよく発生するので残した
        - エラーコード付きのカスタムレスポンスにする？ 

- `DATABASE_CONNECTION_ERROR`を`EXTERNAL_SERVICE_FAILURE`にまとめた
    - インフラ (AWSサービス) のエラーはこれにまとめることに 

- ユースケースで扱うDDBエラーは集約した
    - クライアント由来かサーバー由来かでまとめた 
